### PR TITLE
PacketEncoder and PacketDecoder Typeclasses

### DIFF
--- a/core/src/main/scala/roc/postgresql/ByteDecoders.scala
+++ b/core/src/main/scala/roc/postgresql/ByteDecoders.scala
@@ -9,12 +9,6 @@ trait ByteDecoder[A] {
   def fromBinary(bytes: Option[Array[Byte]]): Error Xor Option[A]
 }
 
-sealed trait FormatCode
-case object Text extends FormatCode
-case object Binary extends FormatCode
-
-object `package` extends ByteDecoderImplicits
-
 trait ByteDecoderImplicits {
 
   implicit val intByteDecoder: ByteDecoder[Int] = new ByteDecoder[Int] {

--- a/core/src/main/scala/roc/postgresql/Messages.scala
+++ b/core/src/main/scala/roc/postgresql/Messages.scala
@@ -2,6 +2,7 @@ package com.github.finagle
 package roc
 package postgresql
 
+import cats.data.Xor
 import cats.std.all._
 import cats.syntax.eq._
 import com.github.finagle.roc.postgresql.transport.{Buffer, BufferReader, BufferWriter, Packet}
@@ -13,35 +14,40 @@ import scala.collection.mutable.ListBuffer
 sealed trait Message
 object Message {
   val AuthenticationRequest: Char = 'R'
-  val ErrorMessage: Char          = 'E'
-  val ParameterStatus: Char       = 'S'
-  val ReadyForQuery: Char         = 'Z'
-  val BackendKeyData: Char        = 'K'
-  val RowDescription: Char        = 'T'
-  val DataRow: Char               = 'D'
-  val CommandComplete: Char       = 'C'
-
-  private[postgresql] def lengthOfCStyleString(str: String): Int = {
-    val bytes = str.getBytes(StandardCharsets.UTF_8)
-    bytes.length + 1
-  }
+  val ErrorByte: Char             = 'E'
+  val ParameterStatusByte: Char   = 'S'
+  val ReadyForQueryByte: Char     = 'Z'
+  val BackendKeyDataByte: Char    = 'K'
+  val RowDescriptionByte: Char    = 'T'
+  val DataRowByte: Char           = 'D'
+  val CommandCompleteByte: Char   = 'C'
+  val PasswordMessageByte: Char   = 'p'
+  val QueryMessageByte: Char      = 'Q'
 }
 
-sealed trait FrontendMessage extends Message {
-  def encode: Packet
+sealed trait FrontendMessage extends Message
+
+case class StartupMessage(user: String, database: String) extends FrontendMessage
+case class Query(queryString: String) extends FrontendMessage
+
+case class PasswordMessage(password: String) extends FrontendMessage
+object PasswordMessage {
+  private[postgresql] def encryptMD5Passwd(user: String, passwd: String, 
+    salt: Array[Byte]): String = {
+      val md = MessageDigest.getInstance("MD5")
+      md.update((passwd + user).getBytes)
+      val unsaltedHexStr = md.digest().map(x => "%02x".format(x.byteValue)).foldLeft("")(_ + _)
+      val saltedBytes = unsaltedHexStr.getBytes ++ salt
+      md.reset()
+      md.update(saltedBytes)
+      md.digest().map(x => "%02x".format(x.byteValue)).foldLeft("md5")(_ + _)
+    }
 }
+
+
 sealed trait BackendMessage extends Message
 
-case class ErrorMessage(byte: Char, reason: String) extends Message
-object ErrorMessage {
-
-  def apply(packet: Packet): Future[ErrorMessage] = {
-    val br       = BufferReader(packet.body)
-    val byte     = br.readByte
-    val response = br.readNullTerminatedString()
-    Future.value(new ErrorMessage(byte.toChar, response))
-  }
-}
+case class ErrorMessage(byte: Char, reason: String) extends BackendMessage
 
 sealed trait AuthenticationMessage extends BackendMessage
 object AuthenticationMessage {
@@ -63,165 +69,49 @@ case object AuthenticationOk extends AuthenticationMessage
 case object AuthenticationClearTxtPasswd extends AuthenticationMessage
 case class AuthenticationMD5Passwd(salt: Array[Byte]) extends AuthenticationMessage
 
-case class ParameterStatusMessage(parameter: String, value: String) extends BackendMessage
-object ParameterStatusMessage {
-  def apply(packet: Packet): Future[ParameterStatusMessage] = {
-    val br = BufferReader(packet.body)
-    val param = br.readNullTerminatedString()
-    val value = br.readNullTerminatedString()
-    Future.value(new ParameterStatusMessage(param, value))
-  }
-}
-
+case class ParameterStatus(parameter: String, value: String) extends BackendMessage
 case class BackendKeyData(processId: Int, secretKey: Int) extends BackendMessage
-object BackendKeyData {
-  def apply(packet: Packet): Future[BackendKeyData] = {
-    val br = BufferReader(packet.body)
-    val procId = br.readInt
-    val secretKey = br.readInt
-    Future.value(new BackendKeyData(procId, secretKey))
-  }
-}
 
-case class ReadyForQuery(transactionStatus: Char) extends BackendMessage
+sealed trait ReadyForQuery extends BackendMessage
 object ReadyForQuery {
-  def apply(packet: Packet): Future[ReadyForQuery] = {
-    val br = BufferReader(packet.body)
-    val tStatus = br.readByte
-    val rfq = new ReadyForQuery(tStatus.toChar)
-    Future.value(rfq)
-  }
-}
-
-case class StartupMessage(user: String, database: String) extends FrontendMessage {
-  import StartupMessage._
-
-  def encode: Packet = {
-    val buffer = BufferWriter(new Array[Byte](lengthOfByteArray(this)))
-    buffer.writeShort(3)
-    buffer.writeShort(0)
-    buffer.writeNullTerminatedString("user")
-    buffer.writeNullTerminatedString(user)
-    buffer.writeNullTerminatedString("database")
-    buffer.writeNullTerminatedString(database)
-    buffer.writeNull
-    Packet(None, Buffer(buffer.toBytes))
-  }
-}
-object StartupMessage {
-  private[postgresql] def lengthOfByteArray(sm: StartupMessage): Int = {
-    val protocolLength  = 4 //2 shorts * 2
-    val lengthOfUserLbl = Message.lengthOfCStyleString("user")
-    val lengthOfUser    = Message.lengthOfCStyleString(sm.user)
-    val lengthOfDbLbl   = Message.lengthOfCStyleString("database")
-    val lengthOfDb      = Message.lengthOfCStyleString(sm.database)
-    val extraNull       = 1
-
-    protocolLength + lengthOfUserLbl + lengthOfUser + lengthOfDbLbl + lengthOfDb + extraNull
-  }
-}
-
-case class Query(queryString: String) extends FrontendMessage {
-  def encode: Packet = {
-    val length = queryString.getBytes.length
-    val bw = BufferWriter(new Array[Byte](length + 1))
-    bw.writeNullTerminatedString(queryString)
-    val bytes = bw.toBytes
-    Packet(Some('Q'), Buffer(bytes))
-  }
-}
-
-case class RowDescription(numFields: Short, fields: List[RowDescriptionField]) extends Message 
-object RowDescription {
-  def apply(packet: Packet): Future[RowDescription] = {
-    val br = BufferReader(packet.body)
-    val numFields = br.readShort
-
-    @annotation.tailrec
-    def loop(currCount: Short, fs: List[RowDescriptionField]): List[RowDescriptionField] =
-      currCount match {
-        case x if x < numFields => {
-          val name = br.readNullTerminatedString()
-          val tableObjectId = br.readInt
-          val tableAttributeId = br.readShort 
-          val dataTypeObjectId = br.readInt
-          val dataTypeSize = br.readShort
-          val typeModifier = br.readInt
-          val formatCode = br.readShort match {
-            case 0 => Text
-            case 1 => Binary
-            case _ => throw new Exception()
-          }
-
-          val rdf = RowDescriptionField(name, tableObjectId, tableAttributeId, dataTypeObjectId,
-            dataTypeSize, typeModifier, formatCode)
-          loop((currCount + 1).toShort, rdf :: fs)
-        }
-        case x if x >= numFields => fs
-      }
-
-    val fs = loop(0, List.empty[RowDescriptionField]).reverse
-    Future.value(RowDescription(numFields, fs))
-  }
-}
-case class RowDescriptionField(name: String, tableObjectId: Int, tableAttributeId: Short,
-  dataTypeObjectId: Int, dataTypeSize: Short, typeModifier: Int, formatCode: FormatCode)
-
-case class PasswordMessage(password: String) extends FrontendMessage {
-  def encode: Packet = {
-    val length = password.getBytes(StandardCharsets.UTF_8).length
-    val bw = BufferWriter(new Array[Byte](length + 1))
-    bw.writeNullTerminatedString(password)
-    Packet(Some('p'), Buffer(bw.toBytes))
-  }
-}
-object PasswordMessage {
-  private[postgresql] def encryptMD5Passwd(user: String, passwd: String, 
-    salt: Array[Byte]): String = {
-      val md = MessageDigest.getInstance("MD5")
-      md.update((passwd + user).getBytes)
-      val unsaltedHexStr = md.digest().map(x => "%02x".format(x.byteValue)).foldLeft("")(_ + _)
-      val saltedBytes = unsaltedHexStr.getBytes ++ salt
-      md.reset()
-      md.update(saltedBytes)
-      md.digest().map(x => "%02x".format(x.byteValue)).foldLeft("md5")(_ + _)
+  def apply(transactionStatus: Char): ReadyForQueryDecodingFailure Xor ReadyForQuery = 
+    transactionStatus match {
+      case 'I' => Xor.Right(Idle)
+      case 'T' => Xor.Right(TransactionBlock)
+      case 'E' => Xor.Right(FailedTransactionBlock)
+      case  c  => Xor.Left(new ReadyForQueryDecodingFailure(c))
     }
 }
 
-case class DataRow(numColumns: Short, columnBytes: List[Option[Array[Byte]]]) extends BackendMessage 
-object DataRow {
-  def apply(packet: Packet): Future[DataRow] = {
-    val br = BufferReader(packet.body)
-    val columns = br.readShort
+case object Idle extends ReadyForQuery
+case object TransactionBlock extends ReadyForQuery
+case object FailedTransactionBlock extends ReadyForQuery
 
-    @annotation.tailrec
-    def loop(idx: Short, cbs: ListBuffer[Option[Array[Byte]]]): List[Option[Array[Byte]]] = 
-      idx match {
-        case x if x < columns => {
-          val columnLength = br.readInt
-          val bytes = if(columnLength == -1) {
-            None
-          } else if(columnLength == 0) {
-            Some(Array.empty[Byte])
-          } else {
-            Some(br.take(columnLength))
+case class RowDescription(numFields: Short, fields: List[RowDescriptionField]) extends BackendMessage 
+case class RowDescriptionField(name: String, tableObjectId: Int, tableAttributeId: Short,
+  dataTypeObjectId: Int, dataTypeSize: Short, typeModifier: Int, formatCode: FormatCode)
+
+sealed trait FormatCode
+case object Text extends FormatCode
+case object Binary extends FormatCode
+
+case class DataRow(numColumns: Short, columnBytes: List[Option[Array[Byte]]]) extends BackendMessage {
+
+  def canEqual(a: Any) = a.isInstanceOf[DataRow]
+
+  final override def equals(that: Any): Boolean = that match {
+    case x: DataRow => {
+      val equalColumnBytes = (columnBytes.length == x.columnBytes.length &&
+        columnBytes.zip(x.columnBytes).forall(y => y._1 match {
+          case None          => y._1 == y._2
+          case Some(leftArr) => y._2 match {
+            case None           => false
+            case Some(rightArr) => leftArr sameElements rightArr
           }
-          loop((idx + 1).toShort, cbs += bytes)
-        }
-        case x if x >= columns => cbs.toList
-      }
-
-    val columnBytes = loop(0, ListBuffer.empty[Option[Array[Byte]]])
-    Future.value(new DataRow(columns, columnBytes))
+        }))
+      x.canEqual(this) && numColumns == x.numColumns && equalColumnBytes
+    }
+    case _ => false
   }
 }
-
 case class CommandComplete(commandTag: String) extends BackendMessage
-object CommandComplete {
-  def apply(packet: Packet): Future[CommandComplete] = {
-    val br = BufferReader(packet.body)
-    val commandTag = br.readNullTerminatedString()
-
-    Future.value(new CommandComplete(commandTag))
-  }
-}

--- a/core/src/main/scala/roc/postgresql/PacketDecoders.scala
+++ b/core/src/main/scala/roc/postgresql/PacketDecoders.scala
@@ -1,0 +1,125 @@
+package com.github.finagle
+package roc
+package postgresql
+
+import cats.data.Xor
+import com.github.finagle.roc.postgresql.transport.{Buffer, BufferReader, Packet}
+import scala.collection.mutable.ListBuffer
+
+private[postgresql] trait PacketDecoder[A <: BackendMessage] {
+  def apply(p: Packet): PacketDecoder.Result[A]
+}
+object PacketDecoder {
+  final type Result[A] = Xor[Error, A]
+}
+
+trait PacketDecoderImplicits {
+  import PacketDecoder._
+
+  implicit val errorMessagePacketDecoder: PacketDecoder[ErrorMessage] = 
+    new PacketDecoder[ErrorMessage] {
+      def apply(p: Packet): Result[ErrorMessage] =
+        Xor.Left(new PacketDecodingFailure("Error messages not implemented yet"))
+    }
+
+  implicit val commandCompletePacketDecoder: PacketDecoder[CommandComplete] = 
+    new PacketDecoder[CommandComplete] {
+      def apply(p: Packet): Result[CommandComplete] = Xor.catchNonFatal({
+        val br = BufferReader(p.body)
+        val commandTag = br.readNullTerminatedString()
+        new CommandComplete(commandTag)
+      }).leftMap(t => new PacketDecodingFailure(t.getMessage))
+    }
+
+  implicit val parameterStatusPacketDecoder: PacketDecoder[ParameterStatus] =
+    new PacketDecoder[ParameterStatus] {
+      def apply(p: Packet): Result[ParameterStatus] = Xor.catchNonFatal({
+        val br = BufferReader(p.body)
+        val param = br.readNullTerminatedString()
+        val value = br.readNullTerminatedString()
+        new ParameterStatus(param, value)
+      }).leftMap(t => new PacketDecodingFailure(t.getMessage))
+    }
+
+  implicit val backendKeyDataPacketDecoder: PacketDecoder[BackendKeyData] = 
+    new PacketDecoder[BackendKeyData] {
+      def apply(p: Packet): Result[BackendKeyData] = Xor.catchNonFatal({
+        val br        = BufferReader(p.body)
+        val processId = br.readInt
+        val secretKey = br.readInt
+        new BackendKeyData(processId, secretKey)
+      }).leftMap(t => new PacketDecodingFailure(t.getMessage))
+    }
+
+  implicit val readyForQueryPacketDecoder: PacketDecoder[ReadyForQuery] =
+    new PacketDecoder[ReadyForQuery] {
+      def apply(p: Packet): Result[ReadyForQuery] = Xor.catchNonFatal({
+        val br   = BufferReader(p.body)
+        val byte = br.readByte
+        byte.toChar
+      })
+      .leftMap(t => new PacketDecodingFailure(t.getMessage))
+      .flatMap(ReadyForQuery(_))
+    }
+
+  implicit val rowDescriptionPacketDecoder: PacketDecoder[RowDescription] = 
+    new PacketDecoder[RowDescription] {
+      def apply(p: Packet): Result[RowDescription] = Xor.catchNonFatal({
+        val br        = BufferReader(p.body)
+        val numFields = br.readShort
+
+        @annotation.tailrec
+        def loop(currCount: Short, fs: List[RowDescriptionField]): List[RowDescriptionField] =
+          currCount match {
+            case x if x < numFields => {
+              val name = br.readNullTerminatedString()
+              val tableObjectId = br.readInt
+              val tableAttributeId = br.readShort 
+              val dataTypeObjectId = br.readInt
+              val dataTypeSize = br.readShort
+              val typeModifier = br.readInt
+              val formatCode = br.readShort match {
+                case 0 => Text
+                case 1 => Binary
+                case _ => throw new Exception()
+              }
+
+              val rdf = RowDescriptionField(name, tableObjectId, tableAttributeId, dataTypeObjectId,
+                dataTypeSize, typeModifier, formatCode)
+              loop((currCount + 1).toShort, rdf :: fs)
+            }
+            case x if x >= numFields => fs
+          }
+
+        val fs = loop(0, List.empty[RowDescriptionField]).reverse
+        RowDescription(numFields, fs)
+      }).leftMap(t => new PacketDecodingFailure(t.getMessage))
+    }
+
+    implicit val dataRowPacketDecoder: PacketDecoder[DataRow] = new PacketDecoder[DataRow] {
+      def apply(p: Packet): Result[DataRow] = Xor.catchNonFatal({
+        val br = BufferReader(p.body)
+        val columns = br.readShort
+
+        @annotation.tailrec
+        def loop(idx: Short, cbs: ListBuffer[Option[Array[Byte]]]): List[Option[Array[Byte]]] = 
+          idx match {
+            case x if x < columns => {
+              val columnLength = br.readInt
+              val bytes = if(columnLength == -1) {
+                None
+              } else if(columnLength == 0) {
+                Some(Array.empty[Byte])
+              } else {
+                Some(br.take(columnLength))
+              }
+              loop((idx + 1).toShort, cbs += bytes)
+            }
+            case x if x >= columns => cbs.toList
+          }
+
+        val columnBytes = loop(0, ListBuffer.empty[Option[Array[Byte]]])
+        new DataRow(columns, columnBytes)
+      }).leftMap(t => new PacketDecodingFailure(t.getMessage))
+    }
+}

--- a/core/src/main/scala/roc/postgresql/PacketEncoders.scala
+++ b/core/src/main/scala/roc/postgresql/PacketEncoders.scala
@@ -1,0 +1,64 @@
+package com.github.finagle
+package roc
+package postgresql
+
+import com.github.finagle.roc.postgresql.transport.{Buffer, BufferWriter, Packet}
+import java.nio.charset.StandardCharsets
+
+private[postgresql] trait PacketEncoder[A <: FrontendMessage] {
+  def apply(a: A): Packet
+}
+
+private[postgresql] object PacketEncoder {
+  def lengthOfStartupMessageByteArray(sm: StartupMessage): Int = {
+    val protocolLength  = 4 //2 shorts * 2
+    val lengthOfUserLbl = lengthOfCStyleString("user")
+    val lengthOfUser    = lengthOfCStyleString(sm.user)
+    val lengthOfDbLbl   = lengthOfCStyleString("database")
+    val lengthOfDb      = lengthOfCStyleString(sm.database)
+    val extraNull       = 1
+
+    protocolLength + lengthOfUserLbl + lengthOfUser + lengthOfDbLbl + lengthOfDb + extraNull
+  }
+
+}
+
+private[postgresql] trait PacketEncoderImplicits {
+  import PacketEncoder._
+
+  implicit val startupMessageEncoder: PacketEncoder[StartupMessage] = 
+    new PacketEncoder[StartupMessage] {
+      def apply(sm: StartupMessage): Packet = {
+        val buffer = BufferWriter(new Array[Byte](lengthOfStartupMessageByteArray(sm)))
+        buffer.writeShort(3)
+        buffer.writeShort(0)
+        buffer.writeNullTerminatedString("user")
+        buffer.writeNullTerminatedString(sm.user)
+        buffer.writeNullTerminatedString("database")
+        buffer.writeNullTerminatedString(sm.database)
+        buffer.writeNull
+        Packet(None, Buffer(buffer.toBytes))
+      }
+    }
+
+  implicit val passwordMessageEncoder: PacketEncoder[PasswordMessage] = 
+    new PacketEncoder[PasswordMessage] {
+      def apply(pm: PasswordMessage): Packet = {
+        val length = pm.password.getBytes(StandardCharsets.UTF_8).length
+        val bw = BufferWriter(new Array[Byte](length + 1))
+        bw.writeNullTerminatedString(pm.password)
+        Packet(Some(Message.PasswordMessageByte), Buffer(bw.toBytes))
+      }
+    }
+
+  implicit val queryMessageEncoder: PacketEncoder[Query] = 
+    new PacketEncoder[Query] {
+      def apply(q: Query): Packet = {
+        val length = q.queryString.getBytes(StandardCharsets.UTF_8).length
+        val bw     = BufferWriter(new Array[Byte](length + 1))
+        bw.writeNullTerminatedString(q.queryString)
+        val bytes  = bw.toBytes
+        Packet(Some(Message.QueryMessageByte), Buffer(bytes))
+      }
+    }
+}

--- a/core/src/main/scala/roc/postgresql/errors.scala
+++ b/core/src/main/scala/roc/postgresql/errors.scala
@@ -35,3 +35,26 @@ final class InvalidAuthenticationRequest(authType: Int) extends Error {
 final class ColumnNotFoundException(symbol: Symbol) extends Error {
   final override def getMessage: String = s"Could not find column $symbol in Result"
 }
+
+final class PacketDecodingFailure(message: String) extends Error {
+  final override def getMessage: String = message
+
+  def canEqual(a: Any) = a.isInstanceOf[PacketDecodingFailure]
+
+  final override def equals(that: Any): Boolean = that match {
+    case x: PacketDecodingFailure => x.canEqual(this) && getMessage == x.getMessage
+    case _ => false
+  }
+}
+
+final class ReadyForQueryDecodingFailure(unknownChar: Char) extends Error {
+  final override def getMessage: String =
+    s"Received unexpected Char $unknownChar from Postgres Server."
+
+  def canEqual(a: Any) = a.isInstanceOf[ReadyForQueryDecodingFailure]
+
+  final override def equals(that: Any): Boolean = that match {
+    case x: ReadyForQueryDecodingFailure => x.canEqual(this) && getMessage == x.getMessage
+    case _ => false
+  }
+}

--- a/core/src/main/scala/roc/postgresql/package.scala
+++ b/core/src/main/scala/roc/postgresql/package.scala
@@ -1,0 +1,28 @@
+package com.github.finagle
+package roc
+
+import com.github.finagle.roc.postgresql.transport.Packet
+import java.nio.charset.StandardCharsets
+
+package object postgresql
+  extends ByteDecoderImplicits
+  with PacketEncoderImplicits 
+  with PacketDecoderImplicits {
+
+  def encodePacket[A <: FrontendMessage: PacketEncoder](a: A): Packet = 
+    implicitly[PacketEncoder[A]].apply(a)
+
+  def decodePacket[A <: BackendMessage: PacketDecoder](p: Packet): PacketDecoder.Result[A] =
+    implicitly[PacketDecoder[A]].apply(p)
+
+  def lengthOfCStyleString(str: String): Int = {
+    val bytes = str.getBytes(StandardCharsets.UTF_8)
+    bytes.length + 1
+  }
+
+  def lengthOfCStyleStrings(xs: List[String]): Int = xs match {
+    case h :: t => xs.map(lengthOfCStyleString).reduce(_ + _)
+    case t      => 0
+  }
+
+}

--- a/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
+++ b/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
@@ -9,11 +9,19 @@ import org.specs2.specification.core._
 final class ErrorsSpec extends Specification with ScalaCheck { def is = s2"""
 
   Error
-    UnknownPostgresTypeFailure should have correct message  $unkownPostgresTypeFailure
+    UnknownPostgresTypeFailure should have correct message    $unkownPostgresTypeFailure
+    ReadyForQueryDecodingFailure should have correct message  $readyForQueryDecodingFailure
+
                                                                          """
   val unkownPostgresTypeFailure = forAll { n: Int =>
     val msg = s"Postgres Object ID $n is unknown"
     val error = new UnknownPostgresTypeFailure(n)
+    error.getMessage must_== msg
+  }
+
+  val readyForQueryDecodingFailure = forAll { c: Char =>
+    val msg = s"Received unexpected Char $c from Postgres Server."
+    val error = new ReadyForQueryDecodingFailure(c)
     error.getMessage must_== msg
   }
 }

--- a/core/src/test/scala/roc/postgresql/MessageSpec.scala
+++ b/core/src/test/scala/roc/postgresql/MessageSpec.scala
@@ -3,18 +3,34 @@ package roc
 package postgresql
 
 import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
 import org.specs2._
 
 final class MessagesSpec extends Specification with ScalaCheck { def is = s2"""
 
-  Message
-    should calculate length of C-Style String               $lengthOfCStyleString
-                                                            """
+  PasswordMessage
+    should MD5 encrypt a password with given salt           $pmEncrypt
+                                                                            """
 
-  val lengthOfCStyleString = forAll { (str: String) =>
-    val bytes  = str.getBytes(StandardCharsets.UTF_8)
-    val length = bytes.length + 1 // add 1 for null character
-    Message.lengthOfCStyleString(str) must_== length
+  val pmEncrypt = forAll { (user: String, pm: PasswordMessage, salt: Array[Byte]) =>
+    val md = MessageDigest.getInstance("MD5")
+    md.update((pm.password+ user).getBytes(StandardCharsets.UTF_8))
+    val unsaltedHexStr = md.digest().map(x => "%02x".format(x.byteValue)).foldLeft("")(_ + _)
+    val saltedBytes = unsaltedHexStr.getBytes ++ salt
+    md.reset()
+    md.update(saltedBytes)
+    val passwd = md.digest().map(x => "%02x".format(x.byteValue)).foldLeft("md5")(_ + _)
+    passwd must_== PasswordMessage.encryptMD5Passwd(user, pm.password, salt)
   }
+  
+  lazy val genByte: Gen[Byte] = arbitrary[Byte]
+  lazy val genSalt: Gen[Array[Byte]] = Gen.containerOfN[Array, Byte](4, genByte)
+  lazy val genPasswordMessage: Gen[PasswordMessage] = for {
+    password    <-  arbitrary[String]
+  } yield new PasswordMessage(password)
+  implicit lazy val implicitPasswordMessage: Arbitrary[PasswordMessage] = 
+    Arbitrary(genPasswordMessage)
 }

--- a/core/src/test/scala/roc/postgresql/PackageSpec.scala
+++ b/core/src/test/scala/roc/postgresql/PackageSpec.scala
@@ -1,0 +1,33 @@
+package com.github.finagle
+package roc
+package postgresql
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2._
+
+final class PackageSpec extends Specification with ScalaCheck { def is = s2"""
+
+  Postgresql Package
+    should calculate length of C-Style String               $test0
+    should calculate length of C-Style Strings              $test1
+                                                                           """
+
+  val test0 = forAll { (str: String) => 
+    val bytes  = str.getBytes(StandardCharsets.UTF_8)
+    val length = bytes.length + 1 // add 1 for null character
+    lengthOfCStyleString(str) must_== length
+  }
+
+  val test1 = forAll { (xs: List[String]) => 
+    val length = xs match {
+      case h :: t => xs.map(lengthOfCStyleString).reduce(_ + _)
+      case t      => 0
+    }
+    lengthOfCStyleStrings(xs) must_== length
+  }
+
+}

--- a/core/src/test/scala/roc/postgresql/PacketDecodersSpec.scala
+++ b/core/src/test/scala/roc/postgresql/PacketDecodersSpec.scala
@@ -1,0 +1,141 @@
+package com.github.finagle
+package roc
+package postgresql
+
+import cats.data.Xor
+import com.github.finagle.roc.postgresql.transport.{Buffer, BufferWriter, Packet}
+import java.nio.charset.StandardCharsets
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2._
+import org.specs2.specification.core._
+import org.specs2.specification.create.FragmentsFactory
+
+final class PacketDecodersSpec extends Specification with ScalaCheck { def is = s2"""
+
+  ErrorMessage
+    should return a PacketDecodingFailure("Error Messages not implemented yet")     ${ErrorMsg().test}
+
+  CommandComplete
+    should return Xor.Right(CommandComplete) when given a valid Packet              ${CmdComplete().test}
+    should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${CmdComplete().testInvalidPacket}
+
+  ParameterStatus
+    should return Xor.Right(ParameterStatus) when given a valid Packet              ${ParamStatus().test}
+    should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${ParamStatus().testInvalidPacket}
+
+  BackendKeyData
+    should return Xor.Right(BackendKeyData) when given a valid Packet               ${BackendKey().test}
+    should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${BackendKey().testInvalidPacket}
+
+  ReadyForQuery
+    should return Xor.Right(ReadyForQuery) when given a valid Char                  ${RFQ().testValid}
+    should return Xor.Left(ReadyForQueryDecodingFailure) when given an invalid Char ${RFQ().testInvalidChar}
+    should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${RFQ().testInvalidPacket}
+
+  RowDescription
+    should return Xor.Right(RowDescription) when given a valid Packet               ${RD().testValidPacket}
+    should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${RD().testInvalidPacket}
+
+  DataRow
+    should return Xor.Right(DataRow) when given a valid Packet                      ${DR().testValidPacket}
+    should return Xor.Left(PacketDecodingFailure) when given an invalid Packet      ${DR().testInvalidPacket}
+                                                                                  """
+
+  case class ErrorMsg() extends generators.ErrorGen {
+    val test = forAll(errorPacket) { (p: Packet) => 
+      decodePacket[ErrorMessage](p) must_== 
+        Xor.Left(new PacketDecodingFailure("Error messages not implemented yet"))
+    }
+  }
+
+  case class CmdComplete() extends generators.CommandCompleteGen {
+    val test = forAll(commandCompleteValidPacket) { (c: CommandCompleteContainer) =>
+      decodePacket[CommandComplete](c.p) must_== Xor.Right(new CommandComplete(c.str))
+    }
+
+    def testInvalidPacket = {
+      val packet = Packet(Some(Message.CommandCompleteByte), Buffer(Array.empty[Byte]))
+      decodePacket[CommandComplete](packet) must_== 
+        Xor.Left(new PacketDecodingFailure("Readable byte limit exceeded: 0"))
+    }
+  }
+
+  case class ParamStatus() extends generators.ParameterStatusGen {
+    val test = forAll { (psc: ParameterStatusContainer) =>
+      decodePacket[ParameterStatus](psc.packet) must_== 
+        Xor.Right(new ParameterStatus(psc.param, psc.value))
+    }
+
+    def testInvalidPacket = {
+      val packet = Packet(Some(Message.CommandCompleteByte), Buffer(Array.empty[Byte]))
+      decodePacket[ParameterStatus](packet) must_== 
+        Xor.Left(new PacketDecodingFailure("Readable byte limit exceeded: 0"))
+    }
+  }
+
+  case class BackendKey() extends generators.BackendKeyGen {
+    val test = forAll { (bkdc: BackendKeyDataContainer) =>
+      val backendKeyData = new BackendKeyData(bkdc.processId, bkdc.secretKey)
+      decodePacket[BackendKeyData](bkdc.packet) must_== Xor.Right(backendKeyData)
+    }
+
+    def testInvalidPacket = {
+      val packet = Packet(Some(Message.CommandCompleteByte), Buffer(Array.empty[Byte]))
+      decodePacket[BackendKeyData](packet) must_== 
+        Xor.Left(new PacketDecodingFailure("Not enough readable bytes - Need 4, maximum is 0"))
+    }
+  }
+
+  case class RFQ() extends generators.ReadyForQueryGen {
+    val testValid = forAll(genValidReadyForQueryContainer) { (rfqc: ReadyForQueryContainer) =>
+      rfqc.transactionStatus match {
+        case 'I' => decodePacket[ReadyForQuery](rfqc.packet) must_== Xor.Right(Idle)
+        case 'T' => decodePacket[ReadyForQuery](rfqc.packet) must_== Xor.Right(TransactionBlock)
+        case 'E' => decodePacket[ReadyForQuery](rfqc.packet) must_== Xor.Right(FailedTransactionBlock)
+        case  c  => decodePacket[ReadyForQuery](rfqc.packet) must_==
+          Xor.Left(new ReadyForQueryDecodingFailure(rfqc.transactionStatus))
+      }
+    }
+
+    val testInvalidChar = forAll(genInvalidReadyForQueryContainer) { (rfqc: ReadyForQueryContainer) =>
+      decodePacket[ReadyForQuery](rfqc.packet) must_==
+        Xor.Left(new ReadyForQueryDecodingFailure(rfqc.transactionStatus))
+    }
+
+    def testInvalidPacket = {
+      val packet = Packet(Some(Message.ReadyForQueryByte), Buffer(Array.empty[Byte]))
+      decodePacket[ReadyForQuery](packet) must_== 
+        Xor.Left(new PacketDecodingFailure("Readable byte limit exceeded: 0"))
+    }
+  }
+
+  case class RD() extends generators.RowDescriptionGen {
+
+    val testValidPacket = forAll(genRowDescriptionContainer) { (rdc: RowDescriptionContainer) => 
+      decodePacket[RowDescription](rdc.packet) must_==
+        Xor.Right(RowDescription(rdc.numFields, rdc.fields))
+    }
+
+    def testInvalidPacket = {
+      val packet = Packet(Some(Message.RowDescriptionByte), Buffer(Array.empty[Byte]))
+      decodePacket[RowDescription](packet) must_==
+        Xor.Left(new PacketDecodingFailure("Not enough readable bytes - Need 2, maximum is 0"))
+    }
+  }
+
+  case class DR() extends generators.DataRowGen {
+    val testValidPacket = forAll { (drc: DataRowContainer) =>
+      val dr = decodePacket[DataRow](drc.packet)
+      decodePacket[DataRow](drc.packet) must_==
+        Xor.Right(DataRow(drc.numColumns, drc.columnBytes))
+    }
+
+    val testInvalidPacket = { 
+      val packet = Packet(Some(Message.DataRowByte), Buffer(Array.empty[Byte]))
+      decodePacket[DataRow](packet) must_==
+        Xor.Left(new PacketDecodingFailure("Not enough readable bytes - Need 2, maximum is 0"))
+    }
+  }
+}

--- a/core/src/test/scala/roc/postgresql/PacketEncodersSpec.scala
+++ b/core/src/test/scala/roc/postgresql/PacketEncodersSpec.scala
@@ -4,7 +4,6 @@ package postgresql
 
 import com.github.finagle.roc.postgresql.transport.{Buffer, BufferWriter, Packet}
 import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll
 import org.scalacheck.{Arbitrary, Gen}
@@ -12,58 +11,50 @@ import org.specs2._
 import org.specs2.specification.core._
 import org.specs2.specification.create.FragmentsFactory
 
-final class AuthenticationMessageSpec extends Specification with ScalaCheck { def is = s2"""
+final class PacketEncodersSpec extends Specification with ScalaCheck { def is = s2"""
 
   PasswordMessage
     should encode starting with 'p'                 $pmEncodeMessageType
     should encode a valid Packet Body               $pmEncodeBody
-    should MD5 encrypt a password with given salt   $pmEncrypt
 
   StartupMessage
     should calculate the length of Body Byte Array  $lengthOfByteArray
     should encode a valid Packet Message Type       $smPacketEncodeMessageType
     should encode a valid Packet Body               $smPacketEncodeBody
-                                                           """
+
+  QueryMessage
+    should encode starting with 'Q'                 $qEncodeMessageType
+    should encode a valid Packet Body               $qEncodeBody
+                                                                                  """
+
   val pmEncodeMessageType = forAll { (pm: PasswordMessage) => 
-    pm.encode.messageType must_== Some('p')
+    encodePacket(pm).messageType must_== Some('p')
   }
 
   val pmEncodeBody = forAll { (pm: PasswordMessage) =>
     val length = pm.password.getBytes(StandardCharsets.UTF_8).length
     val bw     = BufferWriter(new Array[Byte](length + 1))
     bw.writeNullTerminatedString(pm.password)
-    val packet = Packet(Some('p'), Buffer(bw.toBytes))
-    pm.encode.body.underlying must_== packet.body.underlying
-  }
+    val packet = Packet(Some(Message.PasswordMessageByte), Buffer(bw.toBytes))
 
-  val pmEncrypt = forAll { (user: String, pm: PasswordMessage, salt: Array[Byte]) =>
-    val md = MessageDigest.getInstance("MD5")
-    md.update((pm.password+ user).getBytes(StandardCharsets.UTF_8))
-    val unsaltedHexStr = md.digest().map(x => "%02x".format(x.byteValue)).foldLeft("")(_ + _)
-    val saltedBytes = unsaltedHexStr.getBytes ++ salt
-    md.reset()
-    md.update(saltedBytes)
-    val passwd = md.digest().map(x => "%02x".format(x.byteValue)).foldLeft("md5")(_ + _)
-    passwd must_== PasswordMessage.encryptMD5Passwd(user, pm.password, salt)
+    encodePacket(pm).body.underlying must_== packet.body.underlying
   }
 
   val lengthOfByteArray = forAll { (sm: StartupMessage) =>
-    val shorts = 4
-    val i = Message.lengthOfCStyleString("user")
-    val j = Message.lengthOfCStyleString(sm.user)
-    val k = Message.lengthOfCStyleString("database")
-    val l = Message.lengthOfCStyleString(sm.database)
+    val shorts   = 4
+    val length   = lengthOfCStyleStrings( "user" :: sm.user :: "database" :: sm.database :: Nil)
     val lastNull = 1
-    val total = shorts + i + j + k + l + lastNull
-    StartupMessage.lengthOfByteArray(sm) must_== total
+    val total = shorts + length + lastNull
+
+    PacketEncoder.lengthOfStartupMessageByteArray(sm) must_== total
   }
 
   val smPacketEncodeMessageType = forAll { (sm: StartupMessage) =>
-    sm.encode.messageType must_== None
+    encodePacket(sm).messageType must_== None
   }
 
   val smPacketEncodeBody = forAll { (sm: StartupMessage) =>
-    val buffer = BufferWriter(new Array[Byte](StartupMessage.lengthOfByteArray(sm)))
+    val buffer = BufferWriter(new Array[Byte](PacketEncoder.lengthOfStartupMessageByteArray(sm)))
     buffer.writeShort(3)
     buffer.writeShort(0)
     buffer.writeNullTerminatedString("user")
@@ -73,7 +64,21 @@ final class AuthenticationMessageSpec extends Specification with ScalaCheck { de
     buffer.writeNull
     val packet = Packet(None, Buffer(buffer.toBytes))
 
-    sm.encode.body.underlying must_== packet.body.underlying
+    encodePacket(sm).body.underlying must_== packet.body.underlying
+  }
+
+  val qEncodeMessageType = forAll{ (q: Query) => 
+    encodePacket(q).messageType must_== Some('Q')
+  }
+
+  val qEncodeBody = forAll{ (q: Query) => 
+    val length = q.queryString.getBytes(StandardCharsets.UTF_8).length
+    val bw     = BufferWriter(new Array[Byte](length + 1))
+    bw.writeNullTerminatedString(q.queryString)
+    val bytes  = bw.toBytes
+    val packet = Packet(Some(Message.QueryMessageByte), Buffer(bytes))
+
+    encodePacket(q).body.underlying must_== packet.body.underlying
   }
 
   lazy val genPasswordMessage: Gen[PasswordMessage] = for {
@@ -91,6 +96,12 @@ final class AuthenticationMessageSpec extends Specification with ScalaCheck { de
   } yield new StartupMessage(username, database)
   implicit lazy val implicitStartupMessage: Arbitrary[StartupMessage] = 
     Arbitrary(genStartupMessage)
+
+  lazy val genQuery: Gen[Query] = for {
+    queryString <-  arbitrary[String]
+  } yield new Query(queryString)
+  implicit lazy val implicitQuery: Arbitrary[Query] = 
+    Arbitrary(genQuery)
 
   override val ff = fragmentFactory
 }

--- a/core/src/test/scala/roc/postgresql/PostgresqlLexicalGen.scala
+++ b/core/src/test/scala/roc/postgresql/PostgresqlLexicalGen.scala
@@ -1,0 +1,46 @@
+package com.github.finagle
+package roc
+package postgresql
+
+import java.nio.charset.StandardCharsets
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2._
+
+/** Used for generating valid Postgresql Lexical structures
+  *
+  * @see http://www.postgresql.org/docs/current/static/sql-syntax-lexical.html
+  *     for more on what constitues a valid SQL Identifier
+  */
+trait PostgresqlLexicalGen extends ScalaCheck {
+  // see http://www.postgresql.org/docs/current/static/sql-syntax-lexical.html
+  // for more on what constitues a valid SQL Identifier
+  protected val UnicodeCapitalEnglish = '\u0041' to '\u005A'
+  protected val UnicodeLowerEnglish   = '\u0061' to '\u007A'
+  protected val UnicodeNonLatin       = '\u0400' to '\u1FFE'
+  protected val UnicodeUnderscore     = "_".getBytes(StandardCharsets.UTF_8).map(_.toChar).head
+  protected val UnicodeDollarSign     = "$".getBytes(StandardCharsets.UTF_8).map(_.toChar).head
+  protected val UnicodeNumbers        = '\u0030' to '\u0039'
+  protected val BeginningChars = UnicodeUnderscore :: List(UnicodeCapitalEnglish, 
+    UnicodeLowerEnglish, UnicodeNonLatin).flatten
+  protected val SubsequentChars = UnicodeDollarSign :: BeginningChars ::: UnicodeNumbers.toList
+
+  protected lazy val genValidBeginningIdentifier: Gen[Char] = for {
+    char    <-  Gen.oneOf(BeginningChars)
+  } yield char
+  protected lazy val genValidSubsequentIdentifier: Gen[Char] = for {
+    char    <-  Gen.oneOf(SubsequentChars)
+  } yield char
+
+  protected lazy val genValidSQLIdentifier: Gen[String] = for {
+    firstChar   <-  genValidBeginningIdentifier
+    chars       <-  Gen.listOf(genValidSubsequentIdentifier)
+  } yield (firstChar :: chars).foldLeft("")(_ + _)
+
+  protected lazy val genValidNumberOfShortColumns: Gen[Short] =
+    arbitrary[Short] suchThat(s => s >= 0 && s < 1675) // the maximum number of columns is 1663
+  protected lazy val genValidNumberOfIntColumns: Gen[Int] =
+    arbitrary[Int] suchThat(n => n >= 0 && n < 1675) // the maximum number of columns is 1663
+}

--- a/core/src/test/scala/roc/postgresql/generators.scala
+++ b/core/src/test/scala/roc/postgresql/generators.scala
@@ -1,0 +1,220 @@
+package com.github.finagle
+package roc
+package postgresql
+
+import com.github.finagle.roc.postgresql.transport.{Buffer, BufferWriter, Packet}
+import java.nio.charset.StandardCharsets
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2._
+
+object generators {
+
+  trait ErrorGen extends ScalaCheck {
+
+    protected lazy val genByte: Gen[Byte] = arbitrary[Byte]
+    protected lazy val genByteArray: Gen[Array[Byte]] = Gen.containerOf[Array, Byte](genByte)
+
+    implicit lazy val arbitraryErrorBytes: Arbitrary[Array[Byte]] =
+      Arbitrary(genByteArray)
+
+    protected lazy val errorPacket: Gen[Packet] = for {
+      bytes   <-  arbitrary[Array[Byte]]
+    } yield new Packet(Some(Message.ErrorByte), Buffer(bytes))
+
+  }
+
+  trait CommandCompleteGen extends ScalaCheck {
+
+    protected lazy val genCommandString: Gen[String] = Gen.oneOf("INSERT", "DELETE", "UPDATE", 
+      "SELECT", "MOVE", "FETCH", "COPY")
+
+    protected lazy val commandCompleteValidPacket: Gen[CommandCompleteContainer] = for {
+      command <-  genCommandString
+      bw      =   BufferWriter(new Array[Byte](command.length + 1)).writeNullTerminatedString(command)
+    } yield CommandCompleteContainer(command, 
+      new Packet(Some(Message.CommandCompleteByte), Buffer(bw.toBytes)))
+
+    case class CommandCompleteContainer(str: String, p: Packet)
+  }
+
+  trait ParameterStatusGen extends PostgresqlLexicalGen {
+
+    // these are the standard parameters passed back, see
+    // http://www.postgresql.org/docs/current/static/protocol-flow.html
+    protected lazy val genParameter: Gen[String] = Gen.oneOf("server_version", "server_encoding",
+      "client_encoding", "application_name", "is_superuser", "session_authorization",
+      "DateStyle", "IntervalStyle", "TimeZone", "integer_datetimes", "standard_conforming_string")
+    protected lazy val genParameterStatusContainer: Gen[ParameterStatusContainer] = for {
+      param     <-  genParameter
+      value     <-  genValidSQLIdentifier
+      length    =   lengthOfCStyleStrings(param :: value :: Nil)
+    } yield {
+      val bw     =   BufferWriter(new Array[Byte](length))
+      bw.writeNullTerminatedString(param)
+      bw.writeNullTerminatedString(value)
+      val packet    = new Packet(Some(Message.ParameterStatusByte), Buffer(bw.toBytes))
+      new ParameterStatusContainer(param, value, packet)
+    }
+    implicit lazy val arbitraryPSC: Arbitrary[ParameterStatusContainer] =
+      Arbitrary(genParameterStatusContainer)
+
+    case class ParameterStatusContainer(param: String, value: String, packet: Packet)
+  }
+
+  trait BackendKeyGen extends ScalaCheck {
+    protected lazy val genBackendKeyDataContainer: Gen[BackendKeyDataContainer] = for {
+      processId <-  arbitrary[Int]
+      secretKey <-  arbitrary[Int]
+    } yield {
+      val bw = BufferWriter(new Array[Byte](8))
+      bw.writeInt(processId)
+      bw.writeInt(secretKey)
+      val packet = new Packet(Some(Message.BackendKeyDataByte), Buffer(bw.toBytes))
+      new BackendKeyDataContainer(processId, secretKey, packet)
+    }
+
+    implicit lazy val arbitraryBKDC: Arbitrary[BackendKeyDataContainer] =
+      Arbitrary(genBackendKeyDataContainer)
+
+    case class BackendKeyDataContainer(processId: Int, secretKey: Int, packet: Packet)
+  }
+
+  trait ReadyForQueryGen extends ScalaCheck {
+
+    protected lazy val validChars = 'I' :: 'T' :: 'E' :: Nil
+    protected lazy val genValidChar: Gen[Char] = Gen.oneOf[Char](validChars)
+    protected lazy val genInvalidChar: Gen[Byte] = 
+      arbitrary[Byte] suchThat(b => !validChars.contains(b.toChar))
+
+    protected lazy val genValidReadyForQueryContainer: Gen[ReadyForQueryContainer] = for {
+      char  <-  genValidChar
+    } yield new ReadyForQueryContainer(char, packetFromChar(char))
+    protected lazy val genInvalidReadyForQueryContainer: Gen[ReadyForQueryContainer] = for {
+      byte  <-  genInvalidChar
+    } yield new ReadyForQueryContainer(byte.toChar, packetFromChar(byte.toChar)) 
+    protected[this] def packetFromChar(char: Char) = {
+      val bw = BufferWriter(new Array[Byte](5))
+      bw.writeByte(char.toByte)
+      Packet(Some(Message.ReadyForQueryByte), Buffer(bw.toBytes))
+    }
+  
+    case class ReadyForQueryContainer(transactionStatus: Char, packet: Packet)
+  }
+
+  trait RowDescriptionGen extends FormatCodeGen with PostgresqlLexicalGen {
+
+    protected lazy val genRowDescriptionField: Gen[RowDescriptionField] = for {
+      name              <-  genValidSQLIdentifier
+      tableObjectId     <-  arbitrary[Int]
+      tableAttributeId  <-  arbitrary[Short]
+      dataTypeObjectId  <-  arbitrary[Int]
+      dataTypeSize      <-  arbitrary[Short]
+      typeModifier      <-  arbitrary[Int]
+      formatCode        <-  arbitrary[FormatCode]
+    } yield RowDescriptionField(name, tableObjectId, tableAttributeId, dataTypeObjectId,
+        dataTypeSize, typeModifier, formatCode)
+
+    protected lazy val genRowDescriptionContainer: Gen[RowDescriptionContainer] = for {
+      numFields <-  genValidNumberOfShortColumns
+      fields    <-  Gen.listOfN(numFields, genRowDescriptionField)
+    } yield {
+      @annotation.tailrec
+      def calcLength(xs: List[RowDescriptionField], length: Int): Int = xs match {
+        case h :: t => {
+          val fieldLength = lengthOfCStyleString(h.name) + 
+            4 + // 4 Byte tableObjectId Int
+            2 + // 2 Byte tableAttributeId Short
+            4 + // 4 Byte dataTypeObjectId Int
+            2 + // 2 Byte dataTypeSize Short
+            4 + // 4 Byte typeModifier Int
+            2   // 2 Byte formatCode Short
+            calcLength(t, length + fieldLength)
+        }
+        case t      => length
+      }
+      val fieldsLength = calcLength(fields, 0)
+      val length = fieldsLength + 2 // 2 Byte short for number of fields
+      val bw = BufferWriter(new Array[Byte](length))
+      bw.writeShort(numFields)
+      fields.foreach(f => {
+        bw.writeNullTerminatedString(f.name, StandardCharsets.UTF_8)
+        bw.writeInt(f.tableObjectId)
+        bw.writeShort(f.tableAttributeId)
+        bw.writeInt(f.dataTypeObjectId)
+        bw.writeShort(f.dataTypeSize)
+        bw.writeInt(f.typeModifier)
+        f.formatCode match {
+          case Text   => bw.writeShort(0.toShort)
+          case Binary => bw.writeShort(1.toShort)
+        }
+      })
+
+      val packet = Packet(Some(Message.RowDescriptionByte), Buffer(bw.toBytes))
+      new RowDescriptionContainer(numFields, fields, packet)
+    }
+
+    case class RowDescriptionContainer(numFields: Short, fields: List[RowDescriptionField], 
+      packet: Packet)
+  }
+
+  trait DataRowGen extends PostgresqlLexicalGen {
+    protected lazy val genColumnBytes: Gen[Option[Array[Byte]]] = arbitrary[Option[Array[Byte]]]
+    protected lazy val genDataRowContainer: Gen[DataRowContainer] = for {
+      columns   <-  genValidNumberOfShortColumns
+      bytes     <-  Gen.listOfN(columns, genColumnBytes)
+    } yield {
+      val calcBytesLength = (column: Option[Array[Byte]]) => column match {
+        case None     => 0
+        case Some(ab) => ab.length 
+      }
+      val addLengthOfColumn: (Int) => Int = (bytesLength: Int) => bytesLength + 4
+      val calcLengthOfColumn: (Option[Array[Byte]]) => Int =
+        calcBytesLength andThen addLengthOfColumn
+
+      @annotation.tailrec
+      def lengthOfColumns(as: List[Option[Array[Byte]]], length: Int): Int = as match {
+        case h :: t => lengthOfColumns(t, length + calcLengthOfColumn(h))
+        case t      => length
+      }
+
+      val totalLength = lengthOfColumns(bytes, 0) + 2 // 2 Byte short for number of columns
+      val bw = BufferWriter(new Array[Byte](totalLength + 1))
+      bw.writeShort(columns)
+
+      @annotation.tailrec
+      def writeColumns(xs: List[Option[Array[Byte]]]): Unit = xs match {
+        case h :: t => {
+          h match {
+            case Some(b) => {
+              bw.writeInt(b.length)
+              bw.writeBytes(b)
+            }
+            case None    => bw.writeInt(-1)
+          }
+          writeColumns(t)
+        }
+        case t => 
+      }
+
+      val _ = writeColumns(bytes)
+      val packet = Packet(Some(Message.DataRowByte), Buffer(bw.toBytes))
+      new DataRowContainer(columns, bytes, packet)
+    }
+
+    protected lazy implicit val arbitraryDataRowContainer: Arbitrary[DataRowContainer] =
+      Arbitrary(genDataRowContainer)
+
+    case class DataRowContainer(numColumns: Short, columnBytes: List[Option[Array[Byte]]], 
+      packet: Packet)
+  }
+
+  trait FormatCodeGen extends ScalaCheck {
+    protected lazy val genFormatCode: Gen[FormatCode] = Gen.oneOf(Text, Binary)
+
+    implicit lazy val arbitraryFormatCode: Arbitrary[FormatCode] =
+      Arbitrary(genFormatCode)
+  }
+}


### PR DESCRIPTION
    Introduced PackedEncoder and PacketDecoder TypeClasses.

    Packet encoding and Packet decoding have been moved to
    typeclass operations. Decoding returns a result that is a cats
    Disjuntion of either a PacketDecodingFailure or the
    result itself. This being Finagle based, these failures
    and turned into Future.Exceptions. All but
    Authentication Messages have been ported over to use
    the new TypeClasses.

    In addition, a PostgresqlLexicalGen was created to provide
    valid, Lexical correct structures such as identifiers,
    key words, maximum returnable columns, etc. This generator
    is a work in progress.  See
    http://www.postgresql.org/docs/current/static/sql-syntax-lexical.html
    for more information.