### PR TITLE
AuthenticationMessages PacketDecoder typeclass implemented.

### DIFF
--- a/core/src/main/scala/roc/postgresql/ClientDispatcher.scala
+++ b/core/src/main/scala/roc/postgresql/ClientDispatcher.scala
@@ -139,7 +139,11 @@ final class ClientDispatcher(trans: Transport[Packet, Packet],
   }
 
   private[this] def decode(packet: Packet): Future[Message] = packet.messageType match {
-    case Some(mt) if mt === Message.AuthenticationRequest => AuthenticationMessage(packet)
+    case Some(mt) if mt === Message.AuthenticationMessageByte =>
+      decodePacket[AuthenticationMessage](packet) match {
+        case Xor.Right(r) => Future.value(r)
+        case Xor.Left(l)  => Future.exception(l)
+      }
     case Some(mt) if mt === Message.ErrorByte => decodePacket[ErrorMessage](packet) match {
       case Xor.Right(r) => Future.value(r)
       case Xor.Left(l)  => Future.exception(l)

--- a/core/src/main/scala/roc/postgresql/PacketDecoders.scala
+++ b/core/src/main/scala/roc/postgresql/PacketDecoders.scala
@@ -122,4 +122,19 @@ trait PacketDecoderImplicits {
         new DataRow(columns, columnBytes)
       }).leftMap(t => new PacketDecodingFailure(t.getMessage))
     }
+
+  implicit val authenticationMessagePacketDecoder: PacketDecoder[AuthenticationMessage] = 
+    new PacketDecoder[AuthenticationMessage] {
+      def apply(p: Packet): Result[AuthenticationMessage] = Xor.catchNonFatal({
+        val br = BufferReader(p.body)
+        br.readInt match {
+          case 0 => (0, None)
+          case 3 => (3, None)
+          case 5 => (5, Some(br.take(4)))
+          case x => (x, None)
+        }
+      })
+      .leftMap(t => new PacketDecodingFailure(t.getMessage))
+      .flatMap(AuthenticationMessage(_))
+    }
 }

--- a/core/src/main/scala/roc/postgresql/errors.scala
+++ b/core/src/main/scala/roc/postgresql/errors.scala
@@ -27,9 +27,23 @@ final class UnexpectedNoneFailure(message: String) extends Error {
   final override def getMessage: String = message
 }
 
-final class InvalidAuthenticationRequest(authType: Int) extends Error {
-  final override def getMessage: String = 
-    s"Got invalid and unkown Authentication Request: $authType"
+/** Denotes, as of Postgresql Protocol 3.0, an unknown Authentication Request Type.
+  *
+  * @constructor create a new unknown authentication request failure with a request type
+  * @param  requestType the integer representing the unkown request type
+  * @see [[http://www.postgresql.org/docs/current/static/protocol-message-formats.html 
+      Postgresql Message Protocol]]
+ */
+final class UnknownAuthenticationRequestFailure(requestType: Int) extends Error {
+  final override def getMessage: String =
+    s"Unknown Authentication Request Type: $requestType"
+
+  def canEqual(a: Any) = a.isInstanceOf[UnknownAuthenticationRequestFailure]
+
+  final override def equals(that: Any): Boolean = that match {
+    case x: UnknownAuthenticationRequestFailure => x.canEqual(this) && x.getMessage == getMessage
+    case _ => false
+  }
 }
 
 final class ColumnNotFoundException(symbol: Symbol) extends Error {

--- a/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
+++ b/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
@@ -9,11 +9,12 @@ import org.specs2.specification.core._
 final class ErrorsSpec extends Specification with ScalaCheck { def is = s2"""
 
   Error
-    UnknownPostgresTypeFailure should have correct message    $unkownPostgresTypeFailure
-    ReadyForQueryDecodingFailure should have correct message  $readyForQueryDecodingFailure
-
+    UnknownPostgresTypeFailure should have correct message           $unknownPostgresTypeFailure
+    ReadyForQueryDecodingFailure should have correct message         $readyForQueryDecodingFailure
+    UnknownAuthenticationRequestFailure should have correct message  $unknownAuthRequestTypeFailure
                                                                          """
-  val unkownPostgresTypeFailure = forAll { n: Int =>
+
+  val unknownPostgresTypeFailure = forAll { n: Int =>
     val msg = s"Postgres Object ID $n is unknown"
     val error = new UnknownPostgresTypeFailure(n)
     error.getMessage must_== msg
@@ -23,6 +24,12 @@ final class ErrorsSpec extends Specification with ScalaCheck { def is = s2"""
     val msg = s"Received unexpected Char $c from Postgres Server."
     val error = new ReadyForQueryDecodingFailure(c)
     error.getMessage must_== msg
+  }
+
+  val unknownAuthRequestTypeFailure = forAll { n: Int => 
+    val expectedMessage = s"Unknown Authentication Request Type: $n"
+    val error           = new UnknownAuthenticationRequestFailure(n)
+    error.getMessage must_== expectedMessage
   }
 }
 


### PR DESCRIPTION
AuthenticationMessages are now using the PacketDecoder typeclass.
In addition, a new Error type, UnknownAuthenticationRequestFailure,
was created to denote the decoding of any Authentication Request
that is not described by the Postgresql 3.0 protocol found here:
[Postgresql 3.0 Protocol](http://www.postgresql.org/docs/current/static/protocol-message-formats.html).