### PR TITLE
Fleshed out Authentication Messages.

### DIFF
--- a/core/src/main/scala/roc/postgresql/PacketDecoders.scala
+++ b/core/src/main/scala/roc/postgresql/PacketDecoders.scala
@@ -129,9 +129,14 @@ trait PacketDecoderImplicits {
         val br = BufferReader(p.body)
         br.readInt match {
           case 0 => (0, None)
+          case 2 => (2, None)
           case 3 => (3, None)
           case 5 => (5, Some(br.take(4)))
-          case x => (x, None)
+          case 6 => (6, None)
+          case 7 => (7, None)
+          case 8 => (8, Some(br.takeRest))
+          case 9 => (9, None)
+          case n => (n, None)
         }
       })
       .leftMap(t => new PacketDecodingFailure(t.getMessage))

--- a/core/src/main/scala/roc/postgresql/errors.scala
+++ b/core/src/main/scala/roc/postgresql/errors.scala
@@ -46,6 +46,24 @@ final class UnknownAuthenticationRequestFailure(requestType: Int) extends Error 
   }
 }
 
+/** Denotes an Unsupported Authentication Request
+  * @constructor create a new unsupported authentication request failure with a request type
+  * @param messageType the Authentication Message that is unsupported
+  * @see [[http://www.postgresql.org/docs/current/static/protocol-message-formats.html 
+      Postgresql Message Protocol]]
+ */
+final class UnsupportedAuthenticationFailure(messageType: String) extends Error {
+  final override def getMessage: String =
+    s"Unsupported Authentication Failure. $messageType authentication is not supported."
+
+    def canEqual(a: Any) = a.isInstanceOf[UnsupportedAuthenticationFailure]
+
+    final override def equals(that: Any): Boolean = that match {
+      case x: UnsupportedAuthenticationFailure => x.canEqual(this) && x.getMessage == getMessage
+      case _ => false
+    }
+}
+
 final class ColumnNotFoundException(symbol: Symbol) extends Error {
   final override def getMessage: String = s"Could not find column $symbol in Result"
 }

--- a/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
+++ b/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
@@ -9,9 +9,10 @@ import org.specs2.specification.core._
 final class ErrorsSpec extends Specification with ScalaCheck { def is = s2"""
 
   Error
-    UnknownPostgresTypeFailure should have correct message           $unknownPostgresTypeFailure
-    ReadyForQueryDecodingFailure should have correct message         $readyForQueryDecodingFailure
-    UnknownAuthenticationRequestFailure should have correct message  $unknownAuthRequestTypeFailure
+    UnknownPostgresTypeFailure should have correct message        $unknownPostgresTypeFailure
+    ReadyForQueryDecodingFailure should have correct message      $readyForQueryDecodingFailure
+    UnknownAuthenticationFailure should have correct message      $unknownAuthRequestFailure
+    UnsupportedAuthenticationFailure should have correct message  $unsupportedAuthFailure
                                                                          """
 
   val unknownPostgresTypeFailure = forAll { n: Int =>
@@ -26,9 +27,16 @@ final class ErrorsSpec extends Specification with ScalaCheck { def is = s2"""
     error.getMessage must_== msg
   }
 
-  val unknownAuthRequestTypeFailure = forAll { n: Int => 
+  val unknownAuthRequestFailure = forAll { n: Int =>
     val expectedMessage = s"Unknown Authentication Request Type: $n"
     val error           = new UnknownAuthenticationRequestFailure(n)
+    error.getMessage must_== expectedMessage
+  }
+
+  val unsupportedAuthFailure = forAll { s: String =>
+    val expectedMessage =
+      s"Unsupported Authentication Failure. $s authentication is not supported."
+    val error           = new UnsupportedAuthenticationFailure(s)
     error.getMessage must_== expectedMessage
   }
 }

--- a/core/src/test/scala/roc/postgresql/PacketDecodersSpec.scala
+++ b/core/src/test/scala/roc/postgresql/PacketDecodersSpec.scala
@@ -149,9 +149,15 @@ final class PacketDecodersSpec extends Specification with ScalaCheck { def is = 
       val decodedPacket = decodePacket[AuthenticationMessage](amc.packet)
       amc.requestType match {
         case 0  => decodedPacket must_== Xor.Right(AuthenticationOk)
+        case 2  => decodedPacket must_== Xor.Right(AuthenticationKerberosV5)
         case 3  => decodedPacket must_== Xor.Right(AuthenticationClearTxtPasswd)
         case 5  => decodedPacket must_== Xor.Right(new AuthenticationMD5Passwd(amc.salt))
-        case x  => decodedPacket must_== Xor.Left(new ReadyForQueryDecodingFailure('c'))
+        case 6  => decodedPacket must_== Xor.Right(AuthenticationSCMCredential)
+        case 7  => decodedPacket must_== Xor.Right(AuthenticationGSS)
+        case 8  => decodedPacket must_== Xor.Right(new AuthenticationGSSContinue(amc.authBytes))
+        case 9  => decodedPacket must_== Xor.Right(AuthenticationSSPI)
+        case x  => decodedPacket must_==
+          Xor.Left(new UnknownAuthenticationRequestFailure(amc.requestType))
       }
     }
 


### PR DESCRIPTION
Created types to represent all remaining Authentication messages: AuthenticationKerberosV5, AuthenticationSCMCredential, AuthenticationGSS, AuthenticationSSPI, AuthenticationGSSContinue.
PacketDecoder typeclass instances were added for each of these.

A new type, UnexpectedAuthenticationRequest, was added to represent any AuthenticationRequest that does not have an associated type as of Postgresql Protocol 3.0. Please see [Postgres Protocol 3.0](http://www.postgresql.org/docs/current/static/protocol-message-formats.html) for more information.

This address, partially, #6 .