### PR TITLE
Removed race condition for Connection Startup.

### DIFF
--- a/core/src/main/scala/roc/postgresql/ClientDispatcher.scala
+++ b/core/src/main/scala/roc/postgresql/ClientDispatcher.scala
@@ -2,100 +2,56 @@ package com.github.finagle
 package roc
 package postgresql
 
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
-
-import com.google.common.cache.{CacheBuilder, RemovalListener, RemovalNotification}
+import cats.data.Xor
+import cats.std.all._
+import cats.syntax.eq._
+import com.github.finagle.roc.postgresql.transport.Packet
 import com.twitter.finagle.dispatch.GenSerialClientDispatcher
 import com.twitter.finagle.transport.Transport
-import com.twitter.finagle.{CancelledRequestException, Service, WriteException, ServiceProxy}
-import com.twitter.util.{Future, NoFuture, Promise, Return, Try, Throw}
+import com.twitter.finagle.{Service, WriteException}
+import com.twitter.util.{Future, Promise}
 
-import scala.collection.mutable.ListBuffer
-
-import java.util.concurrent.atomic.AtomicReference
-
-import com.github.finagle.roc.postgresql.transport.Packet
-import cats.syntax.eq._
-import cats.std.all._
-
-import cats.data.Xor
-
-final class ClientDispatcher(trans: Transport[Packet, Packet],
+private[roc] final class ClientDispatcher(trans: Transport[Packet, Packet],
   startup: Startup)
   extends GenSerialClientDispatcher[Request, Result, Packet, Packet](trans) {
   import ClientDispatcher._
 
-  private[this] val state = new AtomicReference[Future[_]](Off)
-
   private[this] var backendKeyData: Option[BackendKeyData] = None
-  private[this] var ps: List[ParameterStatus] = Nil
+  private[this] var mutableParamStatuses: List[ParameterStatus] = Nil
 
-  override def apply(req: Request): Future[Result] =
-    state.get match {
-      case Off => for {
-        _     <-  authenticate
-        _     <-  completeStartup
-        resp  <-  super.apply(req)
-      } yield resp
-      case On => super.apply(req)
-    }
+  // this has the potential to be badly constructed if called before
+  // the startup phase has been completed
+  private[roc] lazy val paramStatuses: Map[String, String] =
+    mutableParamStatuses.map(x => (x.parameter, x.value)).toMap
 
-  def exchange[A <: FrontendMessage](fm: A)(implicit f: PacketEncoder[A]): Future[Message] = 
-    trans.write(f(fm)) rescue {
-      wrapWriteException
-    } before {
-      trans.read().flatMap(decode(_))
-    }
+  override def apply(req: Request): Future[Result] = 
+    startupPhase.flatMap(_ => super.apply(req))
 
-  def authenticate: Future[Unit] = {
-    val sm = StartupMessage(startup.username, startup.database)
-    exchange(sm)
-      .flatMap(message => message match {
-        case AuthenticationOk => Future.Done 
-        case AuthenticationClearTxtPasswd => {
-          exchange(new PasswordMessage(startup.password))
-            .flatMap(response => response match {
-              case AuthenticationOk => Future.Done 
-              case Idle => Future.Done
-              case _ => Future.exception(new Exception())
-            })
-        }
-        case AuthenticationMD5Passwd(salt) => {
-          val encryptedPasswd = PasswordMessage.encryptMD5Passwd(startup.username, 
-            startup.password, salt)
-          exchange(new PasswordMessage(encryptedPasswd))
-            .flatMap(response => response match {
-              case AuthenticationOk => Future.Done 
-              case Idle => Future.Done
-              case _ => Future.exception(new Exception())
-            })
-        }
-        case Idle => Future.Done
-        case r => println(r); Future.exception(new Exception())
-      })
-  }
+  /** Performs the Startup phase of a Postgresql Connection.
+    *
+    * The startup phase is performed once per connection prior to any exchanges
+    * between the client and server. Failure to startup renders the service unsuable.
+    * The startup phase consists of two separate but sequential  phases 
+    * 1. Authentication 2. Server Process setting run time parameters
+    * @see [[http://www.postgresql.org/docs/current/static/protocol-flow.html#AEN108589]]
+    */
+  private[this] val startupPhase: Future[Unit] =
+    authenticationPhase.flatMap(_ => serverProcessStartupPhase)
 
-  def completeStartup: Future[Unit] = {
-
-    def go(xs: List[ParameterStatus], ys: List[BackendKeyData]):
-      Future[(List[ParameterStatus], List[BackendKeyData])] = trans.read()
-      .flatMap{ packet => decode(packet).flatMap{ msg => msg match {
-        case p: ParameterStatus  => go(p :: xs, ys)
-        case bkd: BackendKeyData => go(xs, bkd :: ys)
-        case Idle => Future.value((xs, ys))
-        case _ => Future.exception(new Exception())
-      }}
-    }
-
-    go(List.empty[ParameterStatus], List.empty[BackendKeyData])
-      .flatMap(tuple => {
-        ps = tuple._1
-        backendKeyData = tuple._2.headOption
-        state.set(On)
-        Future.Done
-      })
-  }
+  /** Represents one exchange of FrontendMessage => Future[Message] with the server
+    *
+    * From the external Client's point of view, Roc maintains the Finagle abstraction of
+    * Request => Future[Result]. Internally, there may be many messages passed back and
+    * forth between the client and server to build up or complete the Result. This method
+    * represents a one-to-one exchange of [[com.github.finagle.roc.postgresql.Messages]]
+    * with a Postgresql server.
+    */
+  private[this] def exchange[A <: FrontendMessage](fm: A)
+    (implicit f: PacketEncoder[A]): Future[Message] = trans.write(f(fm)) rescue {
+        wrapWriteException
+      } before {
+        trans.read().flatMap(decode(_))
+      }
 
   /**
    * Returns a Future that represents the result of an exchange
@@ -144,7 +100,7 @@ final class ClientDispatcher(trans: Transport[Packet, Packet],
         case Xor.Right(r) => Future.value(r)
         case Xor.Left(l)  => Future.exception(l)
       }
-    case Some(mt) if mt === Message.ErrorByte => decodePacket[ErrorMessage](packet) match {
+    case Some(mt) if mt === Message.ErrorByte => decodePacket[ErrorResponse](packet) match {
       case Xor.Right(r) => Future.value(r)
       case Xor.Left(l)  => Future.exception(l)
     }
@@ -186,12 +142,81 @@ final class ClientDispatcher(trans: Transport[Packet, Packet],
         Future.exception(new Exception())
       }
     }
+
+  /** Performs the Authenticaion portion of the Startup Phase
+    */
+  private[this] def authenticationPhase: Future[Unit] = {
+    val sm = StartupMessage(startup.username, startup.database)
+    exchange(sm).flatMap(message => message match {
+        case AuthenticationOk              => Future.Done
+        case AuthenticationClearTxtPasswd  => clearTxtPasswdMachine
+        case AuthenticationMD5Passwd(salt) => md5PasswdMachine(salt)
+        case AuthenticationKerberosV5      =>
+          Future.exception(new UnsupportedAuthenticationFailure("AuthenticationKerberosV5"))
+        case AuthenticationSCMCredential   =>
+          Future.exception(new UnsupportedAuthenticationFailure("AuthenticationSCMCredential"))
+        case AuthenticationSSPI            =>
+          Future.exception(new UnsupportedAuthenticationFailure("AuthenticationSSPI"))
+        case AuthenticationGSS             =>
+          Future.exception(new UnsupportedAuthenticationFailure("AuthenticationGSS"))
+        case u => println(u); Future.exception(
+          new PostgresqlStateMachineFailure("StartupMessage", u.toString)
+        )
+    })
+  }
+
+  private[this] type ServerProcessValues = (List[ParameterStatus], List[BackendKeyData])
+  private[this] def serverProcessStartupPhase: Future[Unit] = {
+
+    def go(safetyCheck: Int, xs: List[ParameterStatus], 
+      ys: List[BackendKeyData]): Future[ServerProcessValues] = safetyCheck match {
+        // TODO - create an Error type for this
+        case x if x > 1000 => Future.exception(new Exception())
+        case x if x < 1000 => trans.read().flatMap(packet =>
+          decode(packet).flatMap(msg => msg match {
+            case p: ParameterStatus  => go(safetyCheck + 1, p :: xs, ys)
+            case bkd: BackendKeyData => go(safetyCheck + 1, xs, bkd :: ys)
+            case Idle => Future.value((xs, ys))
+            case _ => Future.exception(new Exception())
+          })
+        )
+      }
+
+    go(0, List.empty[ParameterStatus], List.empty[BackendKeyData]).flatMap(tuple => {
+      mutableParamStatuses = tuple._1
+      backendKeyData = tuple._2.headOption
+      Future.Done
+    })
+  }
+
+  /** Performs the AuthenticationCleartextPassword startup sequence
+    */
+  def clearTxtPasswdMachine: Future[Unit] = {
+      val pm = new PasswordMessage(startup.password)
+      exchange(pm).flatMap(response => response match {
+        case AuthenticationOk => Future.Done
+        case ErrorResponse(_, _) => Future.exception(new Exception())
+        case u => Future.exception(
+          new PostgresqlStateMachineFailure("PasswordMessage", u.toString)
+        )
+      })
+    }
+
+
+  /** Performs the AuthenticationMD5Password startup sequence
+    */
+  private[this] def md5PasswdMachine(salt: Array[Byte]): Future[Unit] = {
+    val encryptedPasswd = PasswordMessage.encryptMD5Passwd(startup.username, startup.password,
+      salt)
+    val pm = new PasswordMessage(encryptedPasswd)
+    exchange(pm).flatMap(response => response match {
+      case AuthenticationOk  => Future.Done
+      case er: ErrorResponse => Future.exception(new Exception())
+      case u => Future.exception(new PostgresqlStateMachineFailure("PasswordMessage", u.toString))
+    })
+  }
 }
 object ClientDispatcher {
-
-  private sealed trait ConnStates extends NoFuture
-  private case object Off extends ConnStates
-  private case object On extends ConnStates
 
   private val wrapWriteException: PartialFunction[Throwable, Future[Nothing]] = {
     case exc: Throwable => Future.exception(WriteException(exc))

--- a/core/src/main/scala/roc/postgresql/Messages.scala
+++ b/core/src/main/scala/roc/postgresql/Messages.scala
@@ -47,7 +47,7 @@ object PasswordMessage {
 
 sealed trait BackendMessage extends Message
 
-case class ErrorMessage(byte: Char, reason: String) extends BackendMessage
+case class ErrorResponse(byte: Char, reason: String) extends BackendMessage
 
 sealed trait AuthenticationMessage extends BackendMessage
 object AuthenticationMessage {

--- a/core/src/main/scala/roc/postgresql/PacketDecoders.scala
+++ b/core/src/main/scala/roc/postgresql/PacketDecoders.scala
@@ -16,9 +16,9 @@ object PacketDecoder {
 trait PacketDecoderImplicits {
   import PacketDecoder._
 
-  implicit val errorMessagePacketDecoder: PacketDecoder[ErrorMessage] = 
-    new PacketDecoder[ErrorMessage] {
-      def apply(p: Packet): Result[ErrorMessage] =
+  implicit val errorMessagePacketDecoder: PacketDecoder[ErrorResponse] = 
+    new PacketDecoder[ErrorResponse] {
+      def apply(p: Packet): Result[ErrorResponse] =
         Xor.Left(new PacketDecodingFailure("Error messages not implemented yet"))
     }
 

--- a/core/src/main/scala/roc/postgresql/errors.scala
+++ b/core/src/main/scala/roc/postgresql/errors.scala
@@ -90,3 +90,23 @@ final class ReadyForQueryDecodingFailure(unknownChar: Char) extends Error {
     case _ => false
   }
 }
+
+
+/** Denotes a State Transition with the Postgresql State Machine that should be impossible.
+  *
+  * The Postgresql 3.0 Protocol describes serveral specific connection State Machines depending
+  * on the phase of the connection - StartupPhase ( made up of Authentication Phase and
+  * Server Process Startup Phase ), SimpleQuery Phase. During these phases, it is possible
+  * for a Postgresql Server to transmit a Message that does not make sense given the current
+  * State of the Connection. In practice, these should be extremely rare.
+  * @constructor create a new postgresql state machine failure with a messsage type
+  * @param transmittedMessage the Message transmitted to the Postgresql Server
+  * @param recievedMessage the Message recieved from the Postgresql Server that caused the state 
+  *     transition failure
+  * @see [[http://www.postgresql.org/docs/current/static/protocol-flow.html]]
+ */
+final class PostgresqlStateMachineFailure(transmittedMessage: String, receivedMessage: String)
+  extends Error {
+    final override def getMessage: String =
+      s"State Transition from $transmittedMessage -> $receivedMessage is undefined."
+}

--- a/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
+++ b/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
@@ -13,6 +13,7 @@ final class ErrorsSpec extends Specification with ScalaCheck { def is = s2"""
     ReadyForQueryDecodingFailure should have correct message      $readyForQueryDecodingFailure
     UnknownAuthenticationFailure should have correct message      $unknownAuthRequestFailure
     UnsupportedAuthenticationFailure should have correct message  $unsupportedAuthFailure
+    PostgresqlStateMachineFailure should have correct message     $postgresqlStateMachineFailure
                                                                          """
 
   val unknownPostgresTypeFailure = forAll { n: Int =>
@@ -37,6 +38,12 @@ final class ErrorsSpec extends Specification with ScalaCheck { def is = s2"""
     val expectedMessage =
       s"Unsupported Authentication Failure. $s authentication is not supported."
     val error           = new UnsupportedAuthenticationFailure(s)
+    error.getMessage must_== expectedMessage
+  }
+  
+  val postgresqlStateMachineFailure = forAll { (s1: String, s2: String) =>
+    val expectedMessage = s"State Transition from $s1 -> $s2 is undefined."
+    val error           = new PostgresqlStateMachineFailure(s1, s2)
     error.getMessage must_== expectedMessage
   }
 }

--- a/core/src/test/scala/roc/postgresql/PacketDecodersSpec.scala
+++ b/core/src/test/scala/roc/postgresql/PacketDecodersSpec.scala
@@ -50,7 +50,7 @@ final class PacketDecodersSpec extends Specification with ScalaCheck { def is = 
 
   case class ErrorMsg() extends generators.ErrorGen {
     val test = forAll(errorPacket) { (p: Packet) => 
-      decodePacket[ErrorMessage](p) must_== 
+      decodePacket[ErrorResponse](p) must_== 
         Xor.Left(new PacketDecodingFailure("Error messages not implemented yet"))
     }
   }


### PR DESCRIPTION
The Startup phase of the connection has been ironed out.
ClientDispatcher has been cleaned up to make the code more readable,
particularly the authentication state machines. We are now
ejecting from the Connection when we cannot startup.

Introduced the PostgresqlStateMachineFailure type to represent undefined
transition at any point under any specific phase of the connection.

This also completes work on #6  .