### PR TITLE
Cleaned up packages.

### DIFF
--- a/core/src/main/scala/roc/Postgresql.scala
+++ b/core/src/main/scala/roc/Postgresql.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 
 import com.twitter.finagle._
@@ -10,10 +9,8 @@ import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.util.{Await, Duration, Future}
 import java.net.SocketAddress
-
-import com.github.finagle.roc.postgresql.transport.{Packet, PostgresqlClientPipelineFactory}
-import com.github.finagle.roc.postgresql.{Request, Result}
-import com.github.finagle.roc.postgresql.Startup
+import roc.postgresql.transport.{Packet, PostgresqlClientPipelineFactory}
+import roc.postgresql.{Request, Result, Startup}
 
 trait PostgresqlRichClient { self: com.twitter.finagle.Client[Request, Result] => 
 

--- a/core/src/main/scala/roc/postgresql/ByteDecoders.scala
+++ b/core/src/main/scala/roc/postgresql/ByteDecoders.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/main/scala/roc/postgresql/Client.scala
+++ b/core/src/main/scala/roc/postgresql/Client.scala
@@ -1,11 +1,9 @@
-package com.github.finagle
 package roc
 package postgresql
 
-import com.twitter.finagle.ServiceFactory
 import com.twitter.finagle._
+import com.twitter.finagle.ServiceFactory
 import com.twitter.util.{Closable, Future, Time}
-
 
 object Client {
   def apply (factory: ServiceFactory[Request, Result]): Client = 

--- a/core/src/main/scala/roc/postgresql/ClientDispatcher.scala
+++ b/core/src/main/scala/roc/postgresql/ClientDispatcher.scala
@@ -1,15 +1,14 @@
-package com.github.finagle
 package roc
 package postgresql
 
 import cats.data.Xor
 import cats.std.all._
 import cats.syntax.eq._
-import com.github.finagle.roc.postgresql.transport.Packet
 import com.twitter.finagle.dispatch.GenSerialClientDispatcher
 import com.twitter.finagle.transport.Transport
 import com.twitter.finagle.{Service, WriteException}
 import com.twitter.util.{Future, Promise}
+import roc.postgresql.transport.{Packet, PacketEncoder}
 
 private[roc] final class ClientDispatcher(trans: Transport[Packet, Packet],
   startup: Startup)

--- a/core/src/main/scala/roc/postgresql/Messages.scala
+++ b/core/src/main/scala/roc/postgresql/Messages.scala
@@ -1,14 +1,13 @@
-package com.github.finagle
 package roc
 package postgresql
 
 import cats.data.Xor
 import cats.std.all._
 import cats.syntax.eq._
-import com.github.finagle.roc.postgresql.transport.{Buffer, BufferReader, BufferWriter, Packet}
 import com.twitter.util.Future
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+import roc.postgresql.transport.{Buffer, BufferReader, BufferWriter, Packet}
 import scala.collection.mutable.ListBuffer
 
 sealed trait Message

--- a/core/src/main/scala/roc/postgresql/Request.scala
+++ b/core/src/main/scala/roc/postgresql/Request.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/main/scala/roc/postgresql/Startup.scala
+++ b/core/src/main/scala/roc/postgresql/Startup.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/main/scala/roc/postgresql/errors.scala
+++ b/core/src/main/scala/roc/postgresql/errors.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/main/scala/roc/postgresql/package.scala
+++ b/core/src/main/scala/roc/postgresql/package.scala
@@ -1,7 +1,7 @@
-package com.github.finagle
 package roc
 
-import com.github.finagle.roc.postgresql.transport.Packet
+import roc.postgresql.transport.{PacketDecoder, PacketDecoderImplicits, Packet, PacketEncoder, 
+  PacketEncoderImplicits}
 import java.nio.charset.StandardCharsets
 
 package object postgresql

--- a/core/src/main/scala/roc/postgresql/results.scala
+++ b/core/src/main/scala/roc/postgresql/results.scala
@@ -1,11 +1,10 @@
-package com.github.finagle
 package roc
 package postgresql
 
 import cats.data.Xor
 import cats.Show
-import com.github.finagle.roc.postgresql.transport.BufferReader
 import com.twitter.util.Future
+import roc.postgresql.transport.BufferReader
 
 final class Result(rowDescription: RowDescription, data: List[DataRow]) {
 

--- a/core/src/main/scala/roc/postgresql/transport/Buffer.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Buffer.scala
@@ -1,11 +1,10 @@
-package com.github.finagle
 package roc
 package postgresql
 package transport
 
-import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 import java.nio.ByteOrder
 import java.nio.charset.Charset
+import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 
 object Buffer {
   val NullLength = -1 // denotes a SQL NULL value when reading a length coded binary.

--- a/core/src/main/scala/roc/postgresql/transport/Netty3.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Netty3.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 package transport
@@ -32,7 +31,7 @@ private[roc] final class PacketFrameDecoder extends FrameDecoder {
 
 }
 
-private[roc] final class PacketEncoder extends SimpleChannelDownstreamHandler {
+private[roc] final class PacketWriter extends SimpleChannelDownstreamHandler {
   override def writeRequested(ctx: ChannelHandlerContext, evt: MessageEvent) =
     evt.getMessage match {
       case p: Packet =>
@@ -58,7 +57,7 @@ private[roc] object PostgresqlClientPipelineFactory extends ChannelPipelineFacto
   def getPipeline = {
     val pipeline = Channels.pipeline()
     pipeline.addLast("pgPacketDecoder", new PacketFrameDecoder)
-    pipeline.addLast("pgPacketEncoder", new PacketEncoder)
+    pipeline.addLast("pgPacketWriter", new PacketWriter)
     pipeline
   }
 }

--- a/core/src/main/scala/roc/postgresql/transport/Packet.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Packet.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 package transport

--- a/core/src/main/scala/roc/postgresql/transport/PacketDecoders.scala
+++ b/core/src/main/scala/roc/postgresql/transport/PacketDecoders.scala
@@ -1,19 +1,18 @@
-package com.github.finagle
 package roc
 package postgresql
+package transport
 
 import cats.data.Xor
-import com.github.finagle.roc.postgresql.transport.{Buffer, BufferReader, Packet}
 import scala.collection.mutable.ListBuffer
 
-private[postgresql] trait PacketDecoder[A <: BackendMessage] {
+private[roc] trait PacketDecoder[A <: BackendMessage] {
   def apply(p: Packet): PacketDecoder.Result[A]
 }
-object PacketDecoder {
+private[postgresql] object PacketDecoder {
   final type Result[A] = Xor[Error, A]
 }
 
-trait PacketDecoderImplicits {
+private[postgresql] trait PacketDecoderImplicits {
   import PacketDecoder._
 
   implicit val errorMessagePacketDecoder: PacketDecoder[ErrorResponse] = 

--- a/core/src/main/scala/roc/postgresql/transport/PacketEncoders.scala
+++ b/core/src/main/scala/roc/postgresql/transport/PacketEncoders.scala
@@ -1,8 +1,7 @@
-package com.github.finagle
 package roc
 package postgresql
+package transport
 
-import com.github.finagle.roc.postgresql.transport.{Buffer, BufferWriter, Packet}
 import java.nio.charset.StandardCharsets
 
 private[postgresql] trait PacketEncoder[A <: FrontendMessage] {

--- a/core/src/main/scala/roc/postgresql/types.scala
+++ b/core/src/main/scala/roc/postgresql/types.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
+++ b/core/src/test/scala/roc/postgresql/ErrorsSpec.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/test/scala/roc/postgresql/MessageSpec.scala
+++ b/core/src/test/scala/roc/postgresql/MessageSpec.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/test/scala/roc/postgresql/PackageSpec.scala
+++ b/core/src/test/scala/roc/postgresql/PackageSpec.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/test/scala/roc/postgresql/PostgresqlLexicalGen.scala
+++ b/core/src/test/scala/roc/postgresql/PostgresqlLexicalGen.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/test/scala/roc/postgresql/ResultsSpec.scala
+++ b/core/src/test/scala/roc/postgresql/ResultsSpec.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/test/scala/roc/postgresql/TypesSpec.scala
+++ b/core/src/test/scala/roc/postgresql/TypesSpec.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 

--- a/core/src/test/scala/roc/postgresql/generators.scala
+++ b/core/src/test/scala/roc/postgresql/generators.scala
@@ -1,14 +1,13 @@
-package com.github.finagle
 package roc
 package postgresql
 
-import com.github.finagle.roc.postgresql.transport.{Buffer, BufferWriter, Packet}
 import java.nio.charset.StandardCharsets
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll
 import org.scalacheck.{Arbitrary, Gen}
 import org.specs2._
+import roc.postgresql.transport.{Buffer, BufferWriter, Packet}
 
 object generators {
 

--- a/core/src/test/scala/roc/postgresql/transport/BufferReaderSpec.scala
+++ b/core/src/test/scala/roc/postgresql/transport/BufferReaderSpec.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 package transport

--- a/core/src/test/scala/roc/postgresql/transport/BufferWriterSpec.scala
+++ b/core/src/test/scala/roc/postgresql/transport/BufferWriterSpec.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 package transport

--- a/core/src/test/scala/roc/postgresql/transport/PacketDecodersSpec.scala
+++ b/core/src/test/scala/roc/postgresql/transport/PacketDecodersSpec.scala
@@ -1,9 +1,8 @@
-package com.github.finagle
 package roc
 package postgresql
+package transport
 
 import cats.data.Xor
-import com.github.finagle.roc.postgresql.transport.{Buffer, BufferWriter, Packet}
 import java.nio.charset.StandardCharsets
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll

--- a/core/src/test/scala/roc/postgresql/transport/PacketEncodersSpec.scala
+++ b/core/src/test/scala/roc/postgresql/transport/PacketEncodersSpec.scala
@@ -1,8 +1,7 @@
-package com.github.finagle
 package roc
 package postgresql
+package transport
 
-import com.github.finagle.roc.postgresql.transport.{Buffer, BufferWriter, Packet}
 import java.nio.charset.StandardCharsets
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll

--- a/core/src/test/scala/roc/postgresql/transport/PacketFrameDecoderSpec.scala
+++ b/core/src/test/scala/roc/postgresql/transport/PacketFrameDecoderSpec.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 package transport

--- a/core/src/test/scala/roc/postgresql/transport/PacketSpec.scala
+++ b/core/src/test/scala/roc/postgresql/transport/PacketSpec.scala
@@ -1,4 +1,3 @@
-package com.github.finagle
 package roc
 package postgresql
 package transport


### PR DESCRIPTION
PacketEncoder and PacketDecoder typeclasses have been moved into the transport package.

In addition, com.github.finagle has been removed and is no longer the starting delineator for packages. Now we are using simply roc.