### PR TITLE
Privatized all Types that a potential client doesn't need.

### DIFF
--- a/core/src/main/scala/roc/postgresql/ByteDecoders.scala
+++ b/core/src/main/scala/roc/postgresql/ByteDecoders.scala
@@ -2,6 +2,7 @@ package roc
 package postgresql
 
 import cats.data.Xor
+import roc.postgresql.failures.{ByteDecodingFailure, Failure, UnsupportedDecodingFailure}
 
 trait ByteDecoder[A] {
   def fromText(bytes: Option[Array[Byte]]): Xor[ByteDecodingFailure, Option[A]]

--- a/core/src/main/scala/roc/postgresql/Request.scala
+++ b/core/src/main/scala/roc/postgresql/Request.scala
@@ -1,4 +1,6 @@
 package roc
 package postgresql
 
+/** A Request to send a Postgresql Server
+  */
 case class Request(query: String)

--- a/core/src/main/scala/roc/postgresql/failures.scala
+++ b/core/src/main/scala/roc/postgresql/failures.scala
@@ -5,141 +5,143 @@ import cats.data.NonEmptyList
 import cats.implicits._
 import roc.postgresql.server.PostgresqlMessage
 
-sealed abstract class Failure extends Exception
-
-/** An Error occurring on the Postgresql Server.
-  *
-  * @see [[roc.postgresql.server.ErrorMessage]]
-  */
-final class PostgresqlServerFailure(message: PostgresqlMessage) extends Failure {
-  final override def getMessage: String = message.toString
-}
-
-final class UnknownPostgresTypeFailure(objectId: Int) extends Failure {
-  final override def getMessage: String = s"Postgres Object ID $objectId is unknown"
-
-  def canEqual(a: Any) = a.isInstanceOf[UnknownPostgresTypeFailure]
-
-  final override def equals(that: Any): Boolean = that match {
-    case x: UnknownPostgresTypeFailure => x.canEqual(this) && getMessage == x.getMessage
-    case _ => false
+object failures {
+  sealed abstract class Failure extends Exception
+  
+  /** An Error occurring on the Postgresql Server.
+    *
+    * @see [[roc.postgresql.server.ErrorMessage]]
+    */
+  final class PostgresqlServerFailure(message: PostgresqlMessage) extends Failure {
+    final override def getMessage: String = message.toString
   }
-}
-
-final class ByteDecodingFailure(message: String) extends Failure {
-  final override def getMessage: String = message
-}
-
-final class UnsupportedDecodingFailure(message: String) extends Failure {
-  final override def getMessage: String = message
-}
-
-final class UnexpectedNoneFailure(message: String) extends Failure {
-  final override def getMessage: String = message
-}
-
-/** Denotes, as of Postgresql Protocol 3.0, an unknown Authentication Request Type.
-  *
-  * @constructor create a new unknown authentication request failure with a request type
-  * @param  requestType the integer representing the unkown request type
-  * @see [[http://www.postgresql.org/docs/current/static/protocol-message-formats.html 
-      Postgresql Message Protocol]]
- */
-final class UnknownAuthenticationRequestFailure(requestType: Int) extends Failure {
-  final override def getMessage: String =
-    s"Unknown Authentication Request Type: $requestType"
-
-  def canEqual(a: Any) = a.isInstanceOf[UnknownAuthenticationRequestFailure]
-
-  final override def equals(that: Any): Boolean = that match {
-    case x: UnknownAuthenticationRequestFailure => x.canEqual(this) && x.getMessage == getMessage
-    case _ => false
-  }
-}
-
-/** Denotes an Unsupported Authentication Request
-  * @constructor create a new unsupported authentication request failure with a request type
-  * @param messageType the Authentication Message that is unsupported
-  * @see [[http://www.postgresql.org/docs/current/static/protocol-message-formats.html 
-      Postgresql Message Protocol]]
- */
-final class UnsupportedAuthenticationFailure(messageType: String) extends Failure {
-  final override def getMessage: String =
-    s"Unsupported Authentication Failure. $messageType authentication is not supported."
-
-    def canEqual(a: Any) = a.isInstanceOf[UnsupportedAuthenticationFailure]
-
+  
+  final class UnknownPostgresTypeFailure(objectId: Int) extends Failure {
+    final override def getMessage: String = s"Postgres Object ID $objectId is unknown"
+  
+    def canEqual(a: Any) = a.isInstanceOf[UnknownPostgresTypeFailure]
+  
     final override def equals(that: Any): Boolean = that match {
-      case x: UnsupportedAuthenticationFailure => x.canEqual(this) && x.getMessage == getMessage
+      case x: UnknownPostgresTypeFailure => x.canEqual(this) && getMessage == x.getMessage
       case _ => false
     }
-}
-
-final class ColumnNotFoundException(symbol: Symbol) extends Failure {
-  final override def getMessage: String = s"Could not find column $symbol in Result"
-}
-
-final class PacketDecodingFailure(message: String) extends Failure {
-  final override def getMessage: String = message
-
-  def canEqual(a: Any) = a.isInstanceOf[PacketDecodingFailure]
-
-  final override def equals(that: Any): Boolean = that match {
-    case x: PacketDecodingFailure => x.canEqual(this) && getMessage == x.getMessage
-    case _ => false
   }
-}
-
-final class ReadyForQueryDecodingFailure(unknownChar: Char) extends Failure {
-  final override def getMessage: String =
-    s"Received unexpected Char $unknownChar from Postgres Server."
-
-  def canEqual(a: Any) = a.isInstanceOf[ReadyForQueryDecodingFailure]
-
-  final override def equals(that: Any): Boolean = that match {
-    case x: ReadyForQueryDecodingFailure => x.canEqual(this) && getMessage == x.getMessage
-    case _ => false
+  
+  final class ByteDecodingFailure(message: String) extends Failure {
+    final override def getMessage: String = message
   }
-}
-
-/** Denotes a failure to decode an ErrorResponse from the Postgresql Server
-  *
-  * @constructor creates an error response decoding failure from all error messages
-  * @param xs a [[cats.data.NonEmptyList]] of all decoding failures
-  * @note In practice, these should never occur
-  */
-final class ErrorResponseDecodingFailure private[postgresql]
-  (xs: NonEmptyList[String]) extends Failure {
-  final override def getMessage(): String = xs.foldLeft("")(_ + _ + " ").trim
-
-  def canEqual(a: Any) = a.isInstanceOf[ErrorResponseDecodingFailure]
-
-  final override def equals(that: Any): Boolean = that match {
-    case x: ErrorResponseDecodingFailure => x.canEqual(this) && x.getMessage == getMessage
-    case _ => false
+  
+  final class UnsupportedDecodingFailure(message: String) extends Failure {
+    final override def getMessage: String = message
   }
-}
-
-
-/** Denotes a State Transition with the Postgresql State Machine that should be impossible.
-  *
-  * The Postgresql 3.0 Protocol describes serveral specific connection State Machines depending
-  * on the phase of the connection - StartupPhase ( made up of Authentication Phase and
-  * Server Process Startup Phase ), SimpleQuery Phase. During these phases, it is possible
-  * for a Postgresql Server to transmit a Message that does not make sense given the current
-  * State of the Connection. In practice, these should be extremely rare.
-  * @constructor create a new postgresql state machine failure with a messsage type
-  * @param transmittedMessage the Message transmitted to the Postgresql Server
-  * @param recievedMessage the Message recieved from the Postgresql Server that caused the state 
-  *     transition failure
-  * @see [[http://www.postgresql.org/docs/current/static/protocol-flow.html]]
- */
-final class PostgresqlStateMachineFailure(transmittedMessage: String, receivedMessage: String)
-  extends Failure {
+  
+  final class UnexpectedNoneFailure(message: String) extends Failure {
+    final override def getMessage: String = message
+  }
+  
+  /** Denotes, as of Postgresql Protocol 3.0, an unknown Authentication Request Type.
+    *
+    * @constructor create a new unknown authentication request failure with a request type
+    * @param  requestType the integer representing the unkown request type
+    * @see [[http://www.postgresql.org/docs/current/static/protocol-message-formats.html 
+        Postgresql Message Protocol]]
+   */
+  final class UnknownAuthenticationRequestFailure(requestType: Int) extends Failure {
     final override def getMessage: String =
-      s"State Transition from $transmittedMessage -> $receivedMessage is undefined."
-}
-
-final class UnknownPostgresqlMessageTypeFailure(char: Char) extends Failure {
-  final override def getMessage: String = s"Unknown Postgresql MessageType '$char'."
+      s"Unknown Authentication Request Type: $requestType"
+  
+    def canEqual(a: Any) = a.isInstanceOf[UnknownAuthenticationRequestFailure]
+  
+    final override def equals(that: Any): Boolean = that match {
+      case x: UnknownAuthenticationRequestFailure => x.canEqual(this) && x.getMessage == getMessage
+      case _ => false
+    }
+  }
+  
+  /** Denotes an Unsupported Authentication Request
+    * @constructor create a new unsupported authentication request failure with a request type
+    * @param messageType the Authentication Message that is unsupported
+    * @see [[http://www.postgresql.org/docs/current/static/protocol-message-formats.html 
+        Postgresql Message Protocol]]
+   */
+  final class UnsupportedAuthenticationFailure(messageType: String) extends Failure {
+    final override def getMessage: String =
+      s"Unsupported Authentication Failure. $messageType authentication is not supported."
+  
+      def canEqual(a: Any) = a.isInstanceOf[UnsupportedAuthenticationFailure]
+  
+      final override def equals(that: Any): Boolean = that match {
+        case x: UnsupportedAuthenticationFailure => x.canEqual(this) && x.getMessage == getMessage
+        case _ => false
+      }
+  }
+  
+  final class ColumnNotFoundException(symbol: Symbol) extends Failure {
+    final override def getMessage: String = s"Could not find column $symbol in Result"
+  }
+  
+  final class PacketDecodingFailure(message: String) extends Failure {
+    final override def getMessage: String = message
+  
+    def canEqual(a: Any) = a.isInstanceOf[PacketDecodingFailure]
+  
+    final override def equals(that: Any): Boolean = that match {
+      case x: PacketDecodingFailure => x.canEqual(this) && getMessage == x.getMessage
+      case _ => false
+    }
+  }
+  
+  final class ReadyForQueryDecodingFailure(unknownChar: Char) extends Failure {
+    final override def getMessage: String =
+      s"Received unexpected Char $unknownChar from Postgres Server."
+  
+    def canEqual(a: Any) = a.isInstanceOf[ReadyForQueryDecodingFailure]
+  
+    final override def equals(that: Any): Boolean = that match {
+      case x: ReadyForQueryDecodingFailure => x.canEqual(this) && getMessage == x.getMessage
+      case _ => false
+    }
+  }
+  
+  /** Denotes a failure to decode an ErrorResponse from the Postgresql Server
+    *
+    * @constructor creates an error response decoding failure from all error messages
+    * @param xs a [[cats.data.NonEmptyList]] of all decoding failures
+    * @note In practice, these should never occur
+    */
+  final class ErrorResponseDecodingFailure private[postgresql]
+    (xs: NonEmptyList[String]) extends Failure {
+    final override def getMessage(): String = xs.foldLeft("")(_ + _ + " ").trim
+  
+    def canEqual(a: Any) = a.isInstanceOf[ErrorResponseDecodingFailure]
+  
+    final override def equals(that: Any): Boolean = that match {
+      case x: ErrorResponseDecodingFailure => x.canEqual(this) && x.getMessage == getMessage
+      case _ => false
+    }
+  }
+  
+  
+  /** Denotes a State Transition with the Postgresql State Machine that should be impossible.
+    *
+    * The Postgresql 3.0 Protocol describes serveral specific connection State Machines depending
+    * on the phase of the connection - StartupPhase ( made up of Authentication Phase and
+    * Server Process Startup Phase ), SimpleQuery Phase. During these phases, it is possible
+    * for a Postgresql Server to transmit a Message that does not make sense given the current
+    * State of the Connection. In practice, these should be extremely rare.
+    * @constructor create a new postgresql state machine failure with a messsage type
+    * @param transmittedMessage the Message transmitted to the Postgresql Server
+    * @param recievedMessage the Message recieved from the Postgresql Server that caused the state 
+    *     transition failure
+    * @see [[http://www.postgresql.org/docs/current/static/protocol-flow.html]]
+   */
+  final class PostgresqlStateMachineFailure(transmittedMessage: String, receivedMessage: String)
+    extends Failure {
+      final override def getMessage: String =
+        s"State Transition from $transmittedMessage -> $receivedMessage is undefined."
+  }
+  
+  final class UnknownPostgresqlMessageTypeFailure(char: Char) extends Failure {
+    final override def getMessage: String = s"Unknown Postgresql MessageType '$char'."
+  }
 }

--- a/core/src/main/scala/roc/postgresql/results.scala
+++ b/core/src/main/scala/roc/postgresql/results.scala
@@ -4,6 +4,7 @@ package postgresql
 import cats.data.Xor
 import cats.Show
 import com.twitter.util.Future
+import roc.postgresql.failures._
 import roc.postgresql.transport.BufferReader
 import roc.postgresql.server.PostgresqlMessage
 

--- a/core/src/main/scala/roc/postgresql/server/PostgresqlMessages.scala
+++ b/core/src/main/scala/roc/postgresql/server/PostgresqlMessages.scala
@@ -7,6 +7,7 @@ import cats.data.{NonEmptyList, Validated, ValidatedNel, Xor}
 import cats.Semigroup
 import cats.std.all._
 import cats.syntax.eq._
+import roc.postgresql.failures.{ErrorResponseDecodingFailure, Failure}
 
 /** Represents an error that occured on the Postgresql Server.
   *

--- a/core/src/main/scala/roc/postgresql/server/package.scala
+++ b/core/src/main/scala/roc/postgresql/server/package.scala
@@ -2,7 +2,6 @@ package roc
 package postgresql
 
 package object server {
-
   type Field  = (Char, String)
   type Fields = List[Field]
 }

--- a/core/src/main/scala/roc/postgresql/transport/Buffer.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Buffer.scala
@@ -6,7 +6,7 @@ import java.nio.ByteOrder
 import java.nio.charset.Charset
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 
-object Buffer {
+private[postgresql] object Buffer {
   val NullLength = -1 // denotes a SQL NULL value when reading a length coded binary.
   val EmptyString = new String
 
@@ -30,12 +30,12 @@ object Buffer {
 
 }
 
-sealed trait Buffer {
+private[postgresql] sealed trait Buffer {
   val underlying: ChannelBuffer
   def capacity: Int = underlying.capacity
 }
 
-trait BufferReader extends Buffer {
+private[postgresql] trait BufferReader extends Buffer {
 
   /** Current reader offset in the buffer. */
   def offset: Int
@@ -140,7 +140,7 @@ trait BufferReader extends Buffer {
   def toString(start: Int, length: Int, charset: Charset): String
 }
 
-object BufferReader {
+private[postgresql] object BufferReader {
 
   def apply(buf: Buffer, offset: Int = 0): BufferReader = {
     require(offset >= 0, "Invalid reader offset")
@@ -192,7 +192,7 @@ object BufferReader {
  * that is, all operations increase the offset
  * into the underlying buffer.
  */
-trait BufferWriter extends Buffer {
+private[postgresql] trait BufferWriter extends Buffer {
 
   /**
    * Current writer offset.
@@ -296,7 +296,7 @@ trait BufferWriter extends Buffer {
    }
 }
 
-object BufferWriter {
+private[postgresql] object BufferWriter {
 
   def apply(buf: Buffer, offset: Int = 0): BufferWriter = {
     require(offset >= 0, "Inavlid writer offset.")

--- a/core/src/main/scala/roc/postgresql/transport/Netty3.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Netty3.scala
@@ -31,7 +31,7 @@ private[roc] final class PacketFrameDecoder extends FrameDecoder {
 
 }
 
-private[roc] final class PacketWriter extends SimpleChannelDownstreamHandler {
+private[transport] final class PacketWriter extends SimpleChannelDownstreamHandler {
   override def writeRequested(ctx: ChannelHandlerContext, evt: MessageEvent) =
     evt.getMessage match {
       case p: Packet =>

--- a/core/src/main/scala/roc/postgresql/transport/Packet.scala
+++ b/core/src/main/scala/roc/postgresql/transport/Packet.scala
@@ -4,7 +4,7 @@ package transport
 
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 
-case class Packet(messageType: Option[Char], body: Buffer) {
+private[roc] case class Packet(messageType: Option[Char], body: Buffer) {
 
   def length: Int = body.underlying.capacity + 4
 
@@ -26,6 +26,6 @@ case class Packet(messageType: Option[Char], body: Buffer) {
 }
 
 
-object Packet {
+private[roc] object Packet {
   val HeaderSize = 5
 }

--- a/core/src/main/scala/roc/postgresql/transport/PacketDecoders.scala
+++ b/core/src/main/scala/roc/postgresql/transport/PacketDecoders.scala
@@ -3,10 +3,11 @@ package postgresql
 package transport
 
 import cats.data.Xor
+import roc.postgresql.failures.{Failure, PacketDecodingFailure}
 import roc.postgresql.server.PostgresqlMessage
 import scala.collection.mutable.ListBuffer
 
-private[roc] trait PacketDecoder[A <: BackendMessage] {
+private[postgresql] trait PacketDecoder[A <: BackendMessage] {
   def apply(p: Packet): PacketDecoder.Result[A]
 }
 private[postgresql] object PacketDecoder {

--- a/core/src/test/scala/roc/postgresql/FailuresSpec.scala
+++ b/core/src/test/scala/roc/postgresql/FailuresSpec.scala
@@ -7,6 +7,7 @@ import org.scalacheck.Prop.forAll
 import org.scalacheck.{Arbitrary, Gen}
 import org.specs2._
 import org.specs2.specification.core._
+import roc.postgresql.failures._
 
 final class FailuresSpec extends Specification with ScalaCheck { def is = s2"""
 

--- a/core/src/test/scala/roc/postgresql/ResultsSpec.scala
+++ b/core/src/test/scala/roc/postgresql/ResultsSpec.scala
@@ -7,6 +7,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.specs2._
 import org.specs2.mock.Mockito
 import org.specs2.specification.core._
+import roc.postgresql.failures.ColumnNotFoundException
 
 final class ResultsSpec extends Specification with ScalaCheck with Mockito { def is = s2"""
 

--- a/core/src/test/scala/roc/postgresql/server/PostgresqlMessageSpec.scala
+++ b/core/src/test/scala/roc/postgresql/server/PostgresqlMessageSpec.scala
@@ -13,7 +13,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.specs2._
 import org.specs2.specification.core._
 import org.specs2.specification.create.FragmentsFactory
-import roc.postgresql.ErrorResponseDecodingFailure
+import roc.postgresql.failures.ErrorResponseDecodingFailure
 import roc.postgresql.server.ErrorNoticeMessageFields._
 
 final class PostgresqlMessageSpec extends Specification with ScalaCheck { def is = s2"""

--- a/core/src/test/scala/roc/postgresql/transport/PacketDecodersSpec.scala
+++ b/core/src/test/scala/roc/postgresql/transport/PacketDecodersSpec.scala
@@ -10,6 +10,8 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.specs2._
 import org.specs2.specification.core._
 import org.specs2.specification.create.FragmentsFactory
+import roc.postgresql.failures.{PacketDecodingFailure, ReadyForQueryDecodingFailure,
+  UnknownAuthenticationRequestFailure}
 
 final class PacketDecodersSpec extends Specification with ScalaCheck { def is = s2"""
 


### PR DESCRIPTION
This addresses #31 . All extraneous types have been privatized as tightly as possible to prevent an abstraction leaks. In addition, all failures have been moved under a general failures object.