### PR TITLE
Cleaned up, documented Startup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Once built, open `sbt console` and insert the following
 ```scala
 scala > :paste
 import com.twitter.util.Await
-import com.github.finagle.roc.Postgresql
-import com.github.finagle.roc.postgresql.{Request, Row}
+import roc.Postgresql
+import roc.postgresql.{Request, Row}
 
 val client = Postgresql.client
-  .withCredentials([USER_NAME], Some([DATABASE]))
-  .withPassword([PASSWORD])
-  .newRichClient("localhost:5432")
-val req = new Request("SELECT * FROM states;")
+  .withUserAndPasswd("username", "password")
+  .withDatabase("database")
+  .newRichClient("inet!localhost:5432")
+val req = new Request("SELECT * FROM STATES;")
 val result = Await.result(client.query(req))
 ```
 A result contains two types, a list of columns detailing information about

--- a/core/src/main/scala/roc/Postgresql.scala
+++ b/core/src/main/scala/roc/Postgresql.scala
@@ -1,29 +1,52 @@
 package roc
 
-import com.twitter.finagle._
-import com.twitter.finagle.client.{DefaultPool, StackClient, Transporter, StdStackClient}
-import com.twitter.finagle.netty3.{Netty3Transporter, Netty3Listener}
-import com.twitter.finagle.server.{StackServer, Listener, StdStackServer}
-import com.twitter.finagle.service.{RetryPolicy, TimeoutFilter}
+import com.twitter.finagle.client.{DefaultPool, StackClient, StdStackClient, Transporter}
+import com.twitter.finagle.netty3.Netty3Transporter
 import com.twitter.finagle.transport.Transport
-import com.twitter.finagle.util.DefaultTimer
-import com.twitter.util.{Await, Duration, Future}
-import java.net.SocketAddress
+import com.twitter.finagle.{Name, Service, ServiceFactory, Stack}
+import com.twitter.util.{Duration, Future}
 import roc.postgresql.transport.{Packet, PostgresqlClientPipelineFactory}
 import roc.postgresql.{Request, Result, Startup}
 
-trait PostgresqlRichClient { self: com.twitter.finagle.Client[Request, Result] => 
+/** Rich builder methods for [[roc.Postgresql]]
+  *
+  * Supplements a Finagle Client with convenient builder methods for
+  * constructing a Postgresql Client.
+  */
+trait PostgresqlRichClient { self: com.twitter.finagle.Client[Request, Result] =>
 
-  def newRichClient(dest: Name, label: String): postgresql.Client = 
+  /** 
+    * Creates a new `RichClient` connected to a logical destination described
+    * by `dest` with the assigned `label`. The `label` is used to scope Client stats.
+    */
+  def newRichClient(dest: Name, label: String): postgresql.Client =
     postgresql.Client(newClient(dest, label))
 
-  def newRichClient(dest: String): postgresql.Client = 
+  /**
+    * Creates a new `RichClient` connected to the logical destination described
+    * by `dest`.
+    */
+  def newRichClient(dest: String): postgresql.Client =
     postgresql.Client(newClient(dest))
 }
 
+/** A Finagle Client that connects to Postgresql Server(s).
+  *
+  * @example {{{
+  * val client = Postgresql.client
+  *   .withDatabase("postgres")
+  *   .withUserAndPasswd("username", "password")
+  *   .newRichClient("localhost:5432")
+  * }}}
+  */
 object Postgresql extends com.twitter.finagle.Client[Request, Result] 
   with PostgresqlRichClient {
 
+  /**
+    * Implements a Postgresql client in terms of a Finagle Stack Client.
+    * The client inherits a wealth of features from Finagle including connection 
+    * pooling and load balancing.
+    */
   case class Client(
     stack: Stack[ServiceFactory[Request, Result]] = StackClient.newStack,
     params: Stack.Params = StackClient.defaultParams + DefaultPool.Param(
@@ -44,13 +67,22 @@ object Postgresql extends com.twitter.finagle.Client[Request, Result]
     Service[Request, Result] = postgresql.ClientDispatcher(transport, Startup(params))
   override def configured[P](psp: (P, Stack.Param[P])): Client = super.configured(psp)
 
-  def withCredentials(username: String, database: Option[String]): Client = 
-    configured(Startup.Credentials(username, database))
+  /** The database name for this Postgresql Client to connect to.
+    * @param database the name of the database to connect to
+    */
+  def withDatabase(database: String): Client =
+    configured(Startup.Database(database))
 
-  def withPassword(password: String): Client = 
-    configured(Startup.Password(password))
+  /** The username and password for this Postgresql Client to connect with.
+    * @param username the username for the Postgresql conneciton
+    * @param passwd the password for the Postgresql conneciton
+    */
+  def withUserAndPasswd(username: String, passwd: String): Client = 
+    configured(Startup.Credentials(username, passwd))
   }
 
+  /** Used to construct a Client via the builder pattern.
+    */
   val client = Client()
 
   def newClient(dest: Name, label: String): ServiceFactory[Request, Result] = 

--- a/core/src/main/scala/roc/postgresql/Startup.scala
+++ b/core/src/main/scala/roc/postgresql/Startup.scala
@@ -3,30 +3,43 @@ package postgresql
 
 import com.twitter.finagle.Stack
 
-object Startup {
+/** Represents information required for establishing a connection with a Postgresql server
+  */
+private[roc] object Startup {
 
-  case class Credentials private(username: String, database: String)
-  object Credentials {
-    def apply(username: String, someDb: Option[String]): Credentials = someDb match {
-      case Some(db) => new Credentials(username, db)
-      case None     => new Credentials(username, username)
-    }
+  /** Represents the database name to connect to
+    * @constructor create a new Database with a database name
+    * @param database the name of a Postgresql Database to connect to
+    */ 
+  case class Database(db: String)
+  implicit object DatabaseParam extends Stack.Param[Database] {
+    val default = new Database("postgres")
   }
 
+  /** Represents the Username / Password combination for a Postgresql Connection
+    * @constructor create a new Credentials with a username and password
+    * @param username the username for a Postgresql connection
+    * @param passwd the password for a Postgresql connection
+    */
+  case class Credentials(username: String, passwd: String)
   implicit object CredentialsParam extends Stack.Param[Credentials] {
-    val default = Credentials("postgres", None)
+    val default = Credentials("postgres", "postgres")
   }
 
-  case class Password(password: String)
-  implicit object PasswordParam extends Stack.Param[Password] {
-    val default = new Password("")
-  }
-
+  /** Builds a valid [[roc.postgresql.Startup]] from a [[com.twitter.finagle.Stack]]
+    * @param params [[com.twitter.finagle.Stack.Params]]
+    */
   def apply(params: Stack.Params): Startup = {
-   val Credentials(u, d) = params[Credentials]
-   val Password(p)       = params[Password]
-   new Startup(u, p, d) 
+    val Database(db) = params[Database]
+    val Credentials(user, passwd) = params[Credentials]
+    new Startup(user, passwd, db)
   }
 }
 
-case class Startup private(username: String, password: String, database: String)
+/** Contains all information for starting a [[roc.postgresql.ClientDispatcher]]
+  * @param username the username for a Postgresql conneciton
+  * @param password the password for a Postgresql connection
+  * @param database the database for a Postgresql connection
+  */
+private[roc] case class Startup private[postgresql](username: String, password: String,
+  database: String)

--- a/core/src/test/scala/roc/postgresql/StartupSpecs.scala
+++ b/core/src/test/scala/roc/postgresql/StartupSpecs.scala
@@ -1,0 +1,69 @@
+package roc
+package postgresql
+
+import com.twitter.finagle.client.StackClient
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
+import org.scalacheck.{Arbitrary, Gen}
+import org.specs2._
+import roc.postgresql.Startup.{Database, Credentials}
+
+final class StartupSpecs extends Specification with ScalaCheck { def is = s2"""
+
+  Database
+    must have correct database name $testDatabase
+
+  Credentials
+    must have correct username and password $testUserAndPasswd
+
+  Startup
+    must have correct database, username, and password              $testStartupClass
+    must have correct defaults for username, password, and database $testStartupDefaults
+                                                                            """
+
+  val testDatabase = forAll { dbContainer: DbContainer =>
+    val database = dbContainer.db
+    database.db must_== dbContainer.dbName
+  }
+
+  val testUserAndPasswd = forAll { credentialsContainer: CredentialsContainer =>
+    val expectedCredentials = Credentials(credentialsContainer.username, 
+      credentialsContainer.passwd) 
+    credentialsContainer.credentials must_== expectedCredentials
+  }
+
+  val testStartupClass = forAll { startupContainer: StartupContainer =>
+    val expectedStartup = Startup(startupContainer.username, startupContainer.passwd,
+      startupContainer.database)
+    startupContainer.startup must_== expectedStartup
+  }
+
+  val testStartupDefaults= {
+    val expectedStartup = Startup("postgres", "postgres", "postgres")
+    Startup(StackClient.defaultParams) must_== expectedStartup
+  }
+
+  case class DbContainer(db: Database, dbName: String)
+  private lazy val databaseGen: Gen[DbContainer] = for {
+    db  <-  arbitrary[String]
+  } yield DbContainer(Database(db), db)
+  implicit lazy val arbitraryDatabase: Arbitrary[DbContainer] =
+    Arbitrary(databaseGen)
+
+  case class CredentialsContainer(credentials: Credentials, username: String, passwd: String)
+  private lazy val credentialsContainerGen: Gen[CredentialsContainer] = for {
+    username    <-  arbitrary[String]
+    password    <-  arbitrary[String]
+  } yield CredentialsContainer(Credentials(username, password), username, password)
+  implicit lazy val arbitraryCredentialsContainer: Arbitrary[CredentialsContainer] =
+    Arbitrary(credentialsContainerGen)
+
+  case class StartupContainer(startup: Startup, username: String, passwd: String, database: String)
+  private lazy val startupContainerGen: Gen[StartupContainer] = for {
+    username    <-  arbitrary[String]
+    passwd      <-  arbitrary[String]
+    database    <-  arbitrary[String]
+  } yield StartupContainer(Startup(username, passwd, database), username, passwd, database)
+  implicit lazy val arbitraryStartupContainer: Arbitrary[StartupContainer] =
+    Arbitrary(startupContainerGen)
+}


### PR DESCRIPTION
Startup contained vestiges of initial development when we were simply trying to get Roc off the ground. Now that the ClientDispatcher and Postgresql Client have been somewhat solidified, the Startup type has
been cleaned up with appropriate documenation. We rely on finagle Stack Params to inject parameters and defaults.

In addition, the Postgresql Client and README received some minor tweaks.

This change addresses #24 